### PR TITLE
Action to create a docker image with sources included

### DIFF
--- a/docker-sources-local/action.yml
+++ b/docker-sources-local/action.yml
@@ -4,15 +4,27 @@ on:
   workflow_dispatch:
     inputs:
 #Ex https://zowe.jfrog.io/artifactory/docker-snapshot/ompzowe/base/0.0.1-ubi-amd64.users-jack-base-images-67
-      image_name:
+      image-name:
         description: 'The name of a container image in a registry in the form of [my.registry.address:port/]repositoryname/tag'
         required: true
-      node_version:
+      node-version:
         description: 'Version of nodejs to download source for. If not specified, no source is downloaded'
         required: false
+        default: ""
+      registry-username:
+        description: 'Username to login to the docker registry where the input image exists'
+        required: false
+      registry-password:
+        description: 'Password to login to the docker registry where the input image exists'
+        required: false
+      redhat-registry:
+        description: 'Username to login to the redhat container registry where the input image exists'
+        required: false
+      redhat-password:
+        description: 'Password to login to the redhat container registry where the input image exists'
 
 env:
-  IMAGE_NAME_FULL_REMOTE: ${{ github.event.input.image_name }}-source
+  IMAGE_NAME_FULL_REMOTE: ${{ github.event.input.image-name }}-source
         
 jobs:
   scan:
@@ -20,18 +32,20 @@ jobs:
     timeout-minutes: 120
 
     steps:
-      - name: Login Jfrog
-        uses: docker/login-action@v1
+      - name: Setup docker env
+        uses: zowe-actions/shared-actions/docker-prepare@main
         with:
-          registry: zowe-docker-snapshot.jfrog.io
-          username: ${{ secrets.ARTIFACTORY_X_USERNAME }}
-          password: ${{ secrets.ARTIFACTORY_X_PASSWORD }}
+          registry-user: ${{ github.event.inputs.registry-user }}
+          registry-password: ${{ github.event.inputs.registry-password }}
+          base-directory: ${{github.action_path}}
+          redhat-registry-user:
+          redhat-registry-password:
           
       - name: Make Bill of Materials
         uses: actions/tern-action@v1
         id: scan
         with:
-          image: ${{ github.event.inputs.image_name }}
+          image: ${{ github.event.inputs.image-name }}
           format: json
 #TODO server-bundle.json is hardcoded in generate-attributions, so change this name later.
           output: server-bundle.json
@@ -43,8 +57,7 @@ jobs:
           
       - name: Transform Bill
         run: |
-          wget https://github.com/zowe/zowe-install-packaging/blob/84210fceed278601ca894afcb234c3aaed74b3c8/containers/utils/generate-attributions.js
-          node generate-attributions.js
+          node ${{ github.action_path }}/../utils/generate-attributions.js
 
       - uses: actions/upload-artifact@v2
         with:
@@ -58,20 +71,17 @@ jobs:
     timeout-minutes: 120
 
     steps:
-# Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
       - uses: actions/download-artifact@v2
         with:
           name: NOTICE.txt
           path: NOTICE.txt
           
       - name: Get node source
+        if: ${{ github.events.inputs.NODE_VERSION != "" }}
         run: |
-          if [ -n "${NODE_VERSION}" ]; then wget https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}.tar.xz; fi
+          wget https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}.tar.xz
 
       - uses: zowe-actions/shared-actions/docker-build-local@main
         with:
-          dockerfile: containers/utils/Dockerfile.sources
-          build-arg-list: IMAGE_NAME=${{ github.event.input.image_name }} NODE_VERSION=${{ github.event.input.node_version }}
+          dockerfile: ${{github.action_path}}/../utils/Dockerfile.sources
+          build-arg-list: IMAGE_NAME=${{ github.event.input.image-name }} NODE_VERSION=${{ github.event.input.node-version }}

--- a/docker-sources-local/action.yml
+++ b/docker-sources-local/action.yml
@@ -1,0 +1,77 @@
+name: Generate Source Image
+
+on:
+  workflow_dispatch:
+    inputs:
+#Ex https://zowe.jfrog.io/artifactory/docker-snapshot/ompzowe/base/0.0.1-ubi-amd64.users-jack-base-images-67
+      image_name:
+        description: 'The name of a container image in a registry in the form of [my.registry.address:port/]repositoryname/tag'
+        required: true
+      node_version:
+        description: 'Version of nodejs to download source for. If not specified, no source is downloaded'
+        required: false
+
+env:
+  IMAGE_NAME_FULL_REMOTE: ${{ github.event.input.image_name }}-source
+        
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+
+    steps:
+      - name: Login Jfrog
+        uses: docker/login-action@v1
+        with:
+          registry: zowe-docker-snapshot.jfrog.io
+          username: ${{ secrets.ARTIFACTORY_X_USERNAME }}
+          password: ${{ secrets.ARTIFACTORY_X_PASSWORD }}
+          
+      - name: Make Bill of Materials
+        uses: actions/tern-action@v1
+        id: scan
+        with:
+          image: ${{ github.event.inputs.image_name }}
+          format: json
+#TODO server-bundle.json is hardcoded in generate-attributions, so change this name later.
+          output: server-bundle.json
+
+      - name: Prepare nodejs
+        uses: actions/setup-node@v2
+        with:
+          node-version: '12'
+          
+      - name: Transform Bill
+        run: |
+          wget https://github.com/zowe/zowe-install-packaging/blob/84210fceed278601ca894afcb234c3aaed74b3c8/containers/utils/generate-attributions.js
+          node generate-attributions.js
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: NOTICE.txt
+          path: NOTICE.txt
+        
+          
+          
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+
+    steps:
+# Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - uses: actions/download-artifact@v2
+        with:
+          name: NOTICE.txt
+          path: NOTICE.txt
+          
+      - name: Get node source
+        run: |
+          if [ -n "${NODE_VERSION}" ]; then wget https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}.tar.xz; fi
+
+      - uses: zowe-actions/shared-actions/docker-build-local@main
+        with:
+          dockerfile: containers/utils/Dockerfile.sources
+          build-arg-list: IMAGE_NAME=${{ github.event.input.image_name }} NODE_VERSION=${{ github.event.input.node_version }}

--- a/utils/Dockerfile.sources
+++ b/utils/Dockerfile.sources
@@ -1,0 +1,14 @@
+ARG IMAGE_NAME
+ARG NODE_VERSION
+
+# In the form of  [my.registry.address:port/]repositoryname/tag
+FROM ${IMAGE_NAME}
+
+RUN mkdir -p /root/sources/utils
+COPY get-deb-sources.sh get-dnf-sources.sh /root/sources/utils/
+RUN chmod +x /root/source/utils/*.sh
+RUN type apt>/dev/null; if [ $? == '0' ]; then /root/sources/utils/get-deb-sources.sh; else /root/sources/utils/get-dnf-sources.sh; fi
+
+COPY NOTICE.txt LICENSE.txt /root/
+COPY node-v${NODE_VERSION}.tar.xz /root/sources/
+

--- a/utils/generate-attributions.js
+++ b/utils/generate-attributions.js
@@ -1,0 +1,44 @@
+/*
+This program and the accompanying materials are
+made available under the terms of the Eclipse Public License v2.0 which accompanies
+this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+
+SPDX-License-Identifier: EPL-2.0
+
+Copyright Contributors to the Zowe Project.
+*/
+
+//images->0->image->layers->foreach->packages->name+copyright+proj_url+download_url
+//layers is first-to-last
+const fs = require('fs');
+
+let parent = JSON.parse(fs.readFileSync('server-bundle.json')).images;
+parent = parent[0].image;
+
+let packages = [];
+
+parent.layers.forEach((layer)=> {
+  layer.packages.forEach((package)=> {
+    if (package.copyright) {
+      packages[package.name]=package;
+    }
+  });
+});
+
+let text = 'ATTRIBUTIONS\n\nThe following software is either included in the docker image or was used in making the docker image. Each piece of software is listed by name, version, website if known, and associated copyright text.\n\n';
+
+let packagenames = Object.keys(packages);
+
+packagenames.forEach((packagename)=> {
+  let package = packages[packagename];
+  text+= `\n----------------------------------------\n${package.name} version ${package.version}\n`
+  if (package.proj_url) {
+    website +=`\nWebsite: ${package.proj_url}`
+  }
+  else if (package.download_url) {
+    website +=`\nWebsite: ${package.download_url}`
+  }
+  text+= `\n\nCopyright:\n${package.copyright}\n`
+});
+
+fs.writeFileSync('NOTICE.txt', text);


### PR DESCRIPTION
Related to https://github.com/zowe/zowe-install-packaging/issues/2252 this is an action to use for generating a docker image containing sourcecode given an image that is based upon ubuntu or redhat which has its sources managed in a package manager, aside from nodejs.