### PR TITLE
fix ansible-playbook version in response to regression

### DIFF
--- a/prepare-workflow/action.yml
+++ b/prepare-workflow/action.yml
@@ -67,7 +67,7 @@ runs:
       shell: bash
 
     - name: 'set ansible to 2.14.x (regression #80944)'
-      run: python3 -m pip install --upgrade --user ansible-core==2.14.6
+      run: python3 -m pip install --upgrade --user ansible==7.6.0
       shell: bash
     
     - name: 'export github username and email'

--- a/prepare-workflow/action.yml
+++ b/prepare-workflow/action.yml
@@ -65,6 +65,10 @@ runs:
     - name: 'overwrite jfrog build name'
       run: echo JFROG_CLI_BUILD_NAME=${{ github.event.repository.name }}/${{ env.CURRENT_BRANCH }} >> $GITHUB_ENV
       shell: bash
+
+    - name: 'set ansible to 2.14.x (regression #80944)'
+      run: python3 -m pip install --upgrade --user ansible-core==2.14.6
+      shell: bash
     
     - name: 'export github username and email'
       run: |


### PR DESCRIPTION
Ansible 2.15.0 has a known regression which causes our builds to fail.

This adds a step which forcibly sets Ansible to 2.14.6 (latest 2.14.x at time of writing)