### PR TITLE
Add GitHub action to move project items

### DIFF
--- a/project-move-item/README.md
+++ b/project-move-item/README.md
@@ -1,20 +1,38 @@
-# Action for moving a project item
+# Move Project Item
 
-TODO
+This action updates the Status field of an issue or pull request in a GitHub v2 project. It can be used in workflows triggered by `issue` or `pull_request_target` events.
 
 <br />
 
 ## Inputs
 
-### `lock-repository`
+### `project-owner`
 
-TODO
+**Optional** - The organization that owns the GitHub project. Defaults to `zowe` if not specified.
+
+### `project-number`
+
+**Required** - The GitHub project number. This is the last part of the project URL.
+
+### `project-token`
+
+**Required** - GitHub token with access to read and write projects. We can use `ZOWE_ROBOT_TOKEN`.
+
+### `item-status`
+
+**Required** - The column name (aka Status field) to assign to the project item (e.g., "In Progress").
+
+### `assign-author`
+
+**Optional** - For pull requests, set to `true` to assign author to the PR so that the project can be viewed in "Group By: Assignee" mode. Assignee is only added if they are a team member (with write access) and no one else is assigned. Defaults to `false`.
 
 <br />
 
 ## Outputs
 
-None
+### `itemId`
+
+Item ID of the GitHub project card linked to the issue or pull request.
 
 <br />
 

--- a/project-move-item/README.md
+++ b/project-move-item/README.md
@@ -1,6 +1,6 @@
 # Move Project Item
 
-This action updates the Status field of an issue or pull request in a GitHub v2 project. It can be used in workflows triggered by `issue` or `pull_request_target` events.
+This action updates the Status field of an issue or pull request in a GitHub v2 project. It is designed to be used in workflows triggered by `issue` or `pull_request_target` events.
 
 <br />
 
@@ -21,6 +21,10 @@ This action updates the Status field of an issue or pull request in a GitHub v2 
 ### `item-status`
 
 **Required** - The column name (aka Status field) to assign to the project item (e.g., "In Progress").
+
+## `issue-url`
+
+**Optional** - The GitHub issue or pull request URL. Defaults to the `issue.html_url` or `pull_request.html_url` property on GitHub event payload.
 
 ### `assign-author`
 

--- a/project-move-item/README.md
+++ b/project-move-item/README.md
@@ -1,0 +1,43 @@
+# Action for moving a project item
+
+TODO
+
+<br />
+
+## Inputs
+
+### `lock-repository`
+
+TODO
+
+<br />
+
+## Outputs
+
+None
+
+<br />
+
+## Exported environment variables
+
+None
+
+<br />
+
+## Pre-requisite
+
+None
+
+<br />
+
+## Example usage
+
+(this is a minimal set of inputs you need to provide)
+
+```yaml
+uses: zowe-actions/shared-actions/project-move-item@main
+with:
+  item-status:
+  project-number:
+  project-token:
+```

--- a/project-move-item/action.yml
+++ b/project-move-item/action.yml
@@ -48,7 +48,7 @@ runs:
       id: check-author-permissions
       if: ${{ inputs.assign-author == 'true' && github.event.pull_request && toJSON(github.event.pull_request.assignees) == '[]' }}
       shell: bash
-    - run: gh pr edit ${{ github.event.pull_request.number }} --add-assignee ${{ github.event.pull_request.user.login }}
+    - run: gh pr edit ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --add-assignee ${{ github.event.pull_request.user.login }}
       env:
         GITHUB_TOKEN: ${{ github.token }}
       if: ${{ steps.check-author-permissions.outputs.hasWrite == 'true' }}

--- a/project-move-item/action.yml
+++ b/project-move-item/action.yml
@@ -26,7 +26,7 @@ runs:
   using: 'composite'
   steps:
     - run: |
-        response=$(gh project item-add ${{ inputs.project-number }} --format json --owner ${{ inputs.project-owner }} --url ${{ github.event.issue.url || github.event.pull_request.url }})
+        response=$(gh project item-add ${{ inputs.project-number }} --format json --owner ${{ inputs.project-owner }} --url ${{ github.event.issue.html_url || github.event.pull_request.html_url }})
         echo "itemId=$(echo $response | jq -r '.id')" >> "$GITHUB_OUTPUT"
       env:
         GITHUB_TOKEN: ${{ inputs.project-token }}

--- a/project-move-item/action.yml
+++ b/project-move-item/action.yml
@@ -1,0 +1,49 @@
+name: 'Move Project Item'
+description: 'Update status of issue or pull request in GitHub v2 project'
+inputs:
+  assign-author:
+    description: 'Assign author to pull request if they are on team'
+    required: false
+    default: 'false'
+  item-status:
+    description: 'Column name (Status) to assign to item'
+    required: true
+  project-number:
+    description: 'GitHub project number'
+    required: true
+  project-owner:
+    description: 'Organization that owns GitHub project'
+    required: false
+    default: 'zowe'
+  project-token:
+    description: 'GitHub token with access to read/write projects'
+    required: true
+outputs:
+  itemId:
+    description: 'Item ID of GitHub project card'
+    value: ${{ steps.add-to-project.outputs.itemId }}
+runs:
+  using: 'composite'
+  steps:
+    - run: |
+        response=$(gh project item-add ${{ inputs.project-number }} --format json --owner ${{ inputs.project-owner }} --url ${{ github.event.issue.url || github.event.pull_request.url }})
+        echo "itemId=$(echo $response | jq -r '.id')" >> "$GITHUB_OUTPUT"
+      id: add-to-project
+      shell: bash
+    - uses: titoportas/update-project-fields@v0.1.0
+      with:
+        project-url: https://github.com/orgs/${{ inputs.project-owner }}/projects/${{ inputs.project-number }}
+        github-token: ${{ inputs.project-token }}
+        item-id: ${{ steps.add-to-project.outputs.itemId }}
+        field-keys: Status
+        field-values: ${{ inputs.item-status }}
+    - run: |
+        response=$(curl -fs -H "Authorization: Token ${{ github.token }}" \
+          https://api.github.com/repos/${{ github.repository }}/collaborators/${{ github.event.pull_request.user.login }}/permission)
+        echo "hasWrite=$(echo $response | jq -r '.user.permissions.push')" >> "$GITHUB_OUTPUT"
+      id: check-author-permissions
+      if: ${{ inputs.assign-author == 'true' && github.event.pull_request && toJSON(github.event.pull_request.assignees) == '[]' }}
+      shell: bash
+    - run: gh pr edit ${{ github.event.pull_request.number }} --add-assignee ${{ github.event.pull_request.user.login }}
+      if: ${{ steps.check-author-permissions.outputs.hasWrite == 'true' }}
+      shell: bash

--- a/project-move-item/action.yml
+++ b/project-move-item/action.yml
@@ -40,12 +40,16 @@ runs:
         field-keys: Status
         field-values: ${{ inputs.item-status }}
     - run: |
-        response=$(curl -fs -H "Authorization: Token ${{ github.token }}" \
+        response=$(curl -fs -H "Authorization: Token $GITHUB_TOKEN" \
           https://api.github.com/repos/${{ github.repository }}/collaborators/${{ github.event.pull_request.user.login }}/permission)
         echo "hasWrite=$(echo $response | jq -r '.user.permissions.push')" >> "$GITHUB_OUTPUT"
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
       id: check-author-permissions
       if: ${{ inputs.assign-author == 'true' && github.event.pull_request && toJSON(github.event.pull_request.assignees) == '[]' }}
       shell: bash
     - run: gh pr edit ${{ github.event.pull_request.number }} --add-assignee ${{ github.event.pull_request.user.login }}
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
       if: ${{ steps.check-author-permissions.outputs.hasWrite == 'true' }}
       shell: bash

--- a/project-move-item/action.yml
+++ b/project-move-item/action.yml
@@ -28,6 +28,8 @@ runs:
     - run: |
         response=$(gh project item-add ${{ inputs.project-number }} --format json --owner ${{ inputs.project-owner }} --url ${{ github.event.issue.url || github.event.pull_request.url }})
         echo "itemId=$(echo $response | jq -r '.id')" >> "$GITHUB_OUTPUT"
+      env:
+        GITHUB_TOKEN: ${{ inputs.project-token }}
       id: add-to-project
       shell: bash
     - uses: titoportas/update-project-fields@v0.1.0

--- a/project-move-item/action.yml
+++ b/project-move-item/action.yml
@@ -5,6 +5,9 @@ inputs:
     description: 'Assign author to pull request if they are on team'
     required: false
     default: 'false'
+  issue-url:
+    description: 'GitHub issue URL (required only if event payload is missing)'
+    required: false
   item-status:
     description: 'Column name (Status) to assign to item'
     required: true
@@ -27,7 +30,7 @@ runs:
   using: 'composite'
   steps:
     - run: |
-        response=$(gh project item-add ${{ inputs.project-number }} --format json --owner ${{ inputs.project-owner }} --url ${{ github.event.issue.html_url || github.event.pull_request.html_url }})
+        response=$(gh project item-add ${{ inputs.project-number }} --format json --owner ${{ inputs.project-owner }} --url ${{ inputs.issue-url || github.event.issue.html_url || github.event.pull_request.html_url }})
         echo "itemId=$(echo $response | jq -r '.id')" >> "$GITHUB_OUTPUT"
       env:
         GITHUB_TOKEN: ${{ inputs.project-token }}

--- a/project-move-item/action.yml
+++ b/project-move-item/action.yml
@@ -22,6 +22,7 @@ outputs:
   itemId:
     description: 'Item ID of GitHub project card'
     value: ${{ steps.add-to-project.outputs.itemId }}
+
 runs:
   using: 'composite'
   steps:
@@ -32,6 +33,7 @@ runs:
         GITHUB_TOKEN: ${{ inputs.project-token }}
       id: add-to-project
       shell: bash
+
     - uses: titoportas/update-project-fields@v0.1.0
       with:
         project-url: https://github.com/orgs/${{ inputs.project-owner }}/projects/${{ inputs.project-number }}
@@ -39,6 +41,7 @@ runs:
         item-id: ${{ steps.add-to-project.outputs.itemId }}
         field-keys: Status
         field-values: ${{ inputs.item-status }}
+
     - run: |
         response=$(curl -fs -H "Authorization: Token $GITHUB_TOKEN" \
           https://api.github.com/repos/${{ github.repository }}/collaborators/${{ github.event.pull_request.user.login }}/permission)
@@ -48,6 +51,7 @@ runs:
       id: check-author-permissions
       if: ${{ inputs.assign-author == 'true' && github.event.pull_request && toJSON(github.event.pull_request.assignees) == '[]' }}
       shell: bash
+
     - run: gh pr edit ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --add-assignee ${{ github.event.pull_request.user.login }}
       env:
         GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Here is an example of a simple workflow that uses the action:
```yaml
name: Update GitHub project

on:
  pull_request_target:
    types: [opened, reopened]

jobs:
  update-project:
    name: Add PR to project
    runs-on: ubuntu-latest
    steps:
    - uses: zowe-actions/shared-actions/project-move-item@actions/project-move-item
      with:
        assign-author: true
        item-status: In Progress
        project-number: 21
        project-token: ${{ secrets.ZOWE_ROBOT_TOKEN }}
```

And a successful workflow run: https://github.com/t1m0thyj/zowe-cli/actions/runs/7426090960

And a PR that was successfully added to the "In Progress" column and assigned to author:
![image](https://github.com/zowe-actions/shared-actions/assets/22344007/8fec39b3-f0c1-45da-8cc3-4000510e317f)
