### PR TITLE
Sigstore / cosign integration into publish action

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "homepage": "https://github.com/zowe-actions/shared-actions#readme",
   "dependencies": {
     "@actions/core": "^1.10.0",
-    "@actions/github": "5.0.0",
+    "@actions/github": "^5.0.0",
     "debug": "4.3.2",
     "glob": "7.1.7",
     "js-yaml": "4.1.0",

--- a/publish/action.yml
+++ b/publish/action.yml
@@ -8,6 +8,10 @@ inputs:
     description: 'flag to perform steps to release'
     required: false
     default: 'false'
+  sigstore-sign-artifacts:
+    description: 'use cosign to sign the artifacts as blobs'
+    required: false
+    default: 'false'
   pre-release-string:
     description: 'pre-release string'
     required: false
@@ -25,5 +29,10 @@ inputs:
     default: 'false'
     
 runs:
-  using: 'node12'
-  main: 'dist/index.js'
+  using: 'composite'
+  steps: 
+    - name: Install Cosign
+      uses: sigstore/cosign-installer@v3.3.0
+      if: ${{ github.event.inputs.sigstore-sign-artifacts == 'true' }} 
+    - uses: node18
+      run: 'dist/index.js'

--- a/publish/action.yml
+++ b/publish/action.yml
@@ -43,12 +43,12 @@ runs:
       run: node ${GITHUB_ACTION_PATH}/dist/index.js
       shell: bash
       env:
-        INPUT_perform-release: ${{ inputs.perform-release }}
-        INPUT_sigstore-sign-artifacts: ${{ inputs.sigstore-sign-artifacts }}
-        INPUT_pre-release-string: ${{ inputs.pre-release-string }}
-        INPUT_publish-target-path-pattern: ${{ inputs.publish-target-path-pattern }}
-        INPUT_publish-target-file-pattern: ${{ inputs.publish-target-file-pattern }}
-        INPUT_skip-upload: ${{ inputs.skip-upload }}
-        INPUT_artifacts: ${{ inputs.artifacts }}
+        INPUT_PERFORM-RELEASE: ${{ inputs.perform-release }}
+        INPUT_SIGSTORE-SIGN-ARTIFACTS: ${{ inputs.sigstore-sign-artifacts }}
+        INPUT_PRE-RELEASE-STRING: ${{ inputs.pre-release-string }}
+        INPUT_PUBLISH-TARGET-PATH-PATTERN: ${{ inputs.publish-target-path-pattern }}
+        INPUT_PUBLISH-TARGET-FILE-PATTERN: ${{ inputs.publish-target-file-pattern }}
+        INPUT_SKIP-UPLOAD: ${{ inputs.skip-upload }}
+        INPUT_ARTIFACTS: ${{ inputs.artifacts }}
 
 

--- a/publish/action.yml
+++ b/publish/action.yml
@@ -39,7 +39,7 @@ runs:
       with:
         node-version: 16
     - name: Run publish
-      run: node ${{ github.action_path }}/dist/index.js
+      run: node ${{ github.action_path }}/publish/dist/index.js
       shell: bash
       env:
         INPUTS: ${{ toJSON(inputs) }}

--- a/publish/action.yml
+++ b/publish/action.yml
@@ -43,11 +43,12 @@ runs:
       run: node ${GITHUB_ACTION_PATH}/dist/index.js
       shell: bash
       env:
-        INPUT_artifacts: ${{ inputs.artifacts }}
         INPUT_perform-release: ${{ inputs.perform-release }}
         INPUT_sigstore-sign-artifacts: ${{ inputs.sigstore-sign-artifacts }}
         INPUT_pre-release-string: ${{ inputs.pre-release-string }}
         INPUT_publish-target-path-pattern: ${{ inputs.publish-target-path-pattern }}
         INPUT_publish-target-file-pattern: ${{ inputs.publish-target-file-pattern }}
         INPUT_skip-upload: ${{ inputs.skip-upload }}
+        INPUT_artifacts: ${{ inputs.artifacts }}
+
 

--- a/publish/action.yml
+++ b/publish/action.yml
@@ -38,9 +38,12 @@ runs:
       uses: actions/setup-node@v3.6.0
       with:
         node-version: 16
-    - name: Debug Info
-      run: ls -lask ${{ github.action_path }}
+    - name: Debug Info-BASH
+      run: ls -lask ${GITHUB_ACTION_PATH}
       shell: bash
+    - name: Debug Info-SH
+      run: ls -lask ${GITHUB_ACTION_PATH}
+      shell: sh
     - name: Run publish
       run: node ${{ github.action_path }}/dist/index.js
       shell: bash

--- a/publish/action.yml
+++ b/publish/action.yml
@@ -39,7 +39,7 @@ runs:
       with:
         node-version: 16
     - name: Run publish
-      run: node ${{ github.action_path }}/publish/dist/index.js
+      run: node ${{ github.action_path }}/dist/index.js
       shell: bash
       env:
         INPUTS: ${{ toJSON(inputs) }}

--- a/publish/action.yml
+++ b/publish/action.yml
@@ -33,13 +33,13 @@ runs:
   steps: 
     - name: Install Cosign
       uses: sigstore/cosign-installer@v3.3.0
-      if: ${{ github.event.inputs.sigstore-sign-artifacts == 'true' }} 
+      if: ${{ inputs.sigstore-sign-artifacts == 'true' }} 
     - name: setup node
       uses: actions/setup-node@v3.6.0
       with:
         node-version: 16
     - name: Run publish
-      run: node dist/index.js
+      run: node ${{ github.action_path }}/dist/index.js
       shell: bash
       env:
         INPUTS: ${{ toJSON(inputs) }}

--- a/publish/action.yml
+++ b/publish/action.yml
@@ -34,5 +34,12 @@ runs:
     - name: Install Cosign
       uses: sigstore/cosign-installer@v3.3.0
       if: ${{ github.event.inputs.sigstore-sign-artifacts == 'true' }} 
-    - uses: node18
-      run: 'dist/index.js'
+    - name: setup node
+      uses: actions/setup-node@v3.6.0
+      with:
+        node-version: 16
+    - name: Run publish
+      run: node dist/index.js
+      shell: bash
+      env:
+        INPUTS: ${{ toJSON(inputs) }}

--- a/publish/action.yml
+++ b/publish/action.yml
@@ -1,6 +1,7 @@
 name: "Publish"
 description: "Publish to artifactory for all project builds"
 inputs:
+  # Dev Note: These inputs must be mapped to an env INPUT_* below due to a composite action limitation
   artifacts:
     description: 'artifacts to upload, also support multiple line inputs'
     required: false
@@ -42,4 +43,11 @@ runs:
       run: node ${GITHUB_ACTION_PATH}/dist/index.js
       shell: bash
       env:
-        INPUTS: ${{ toJSON(inputs) }}
+        INPUT_artifacts: ${{ inputs.artifacts }}
+        INPUT_perform-release: ${{ inputs.perform-release }}
+        INPUT_sigstore-sign-artifacts: ${{ inputs.sigstore-sign-artifacts }}
+        INPUT_pre-release-string: ${{ inputs.pre-release-string }}
+        INPUT_publish-target-path-pattern: ${{ inputs.publish-target-path-pattern }}
+        INPUT_publish-target-file-pattern: ${{ inputs.publish-target-file-pattern }}
+        INPUT_skip-upload: ${{ inputs.skip-upload }}
+

--- a/publish/action.yml
+++ b/publish/action.yml
@@ -38,14 +38,8 @@ runs:
       uses: actions/setup-node@v3.6.0
       with:
         node-version: 16
-    - name: Debug Info-BASH
-      run: ls -lask ${GITHUB_ACTION_PATH}
-      shell: bash
-    - name: Debug Info-SH
-      run: ls -lask ${GITHUB_ACTION_PATH}
-      shell: sh
     - name: Run publish
-      run: node ${{ github.action_path }}/dist/index.js
+      run: node ${GITHUB_ACTION_PATH}/dist/index.js
       shell: bash
       env:
         INPUTS: ${{ toJSON(inputs) }}

--- a/publish/action.yml
+++ b/publish/action.yml
@@ -38,6 +38,9 @@ runs:
       uses: actions/setup-node@v3.6.0
       with:
         node-version: 16
+    - name: Debug Info
+      run: ls -lask ${{ github.action_path }}
+      shell: bash
     - name: Run publish
       run: node ${{ github.action_path }}/dist/index.js
       shell: bash

--- a/publish/dist/index.js
+++ b/publish/dist/index.js
@@ -404,9 +404,6 @@ function getBooleanInput(name, options) {
     const trueValue = ['true', 'True', 'TRUE'];
     const falseValue = ['false', 'False', 'FALSE'];
     const val = getInput(name, options);
-    console.log(val)
-    console.log(name)
-    console.log(options)
     if (trueValue.includes(val))
         return true;
     if (falseValue.includes(val))

--- a/publish/dist/index.js
+++ b/publish/dist/index.js
@@ -404,6 +404,9 @@ function getBooleanInput(name, options) {
     const trueValue = ['true', 'True', 'TRUE'];
     const falseValue = ['false', 'False', 'FALSE'];
     const val = getInput(name, options);
+    console.log(val)
+    console.log(name)
+    console.log(options)
     if (trueValue.includes(val))
         return true;
     if (falseValue.includes(val))

--- a/publish/index.js
+++ b/publish/index.js
@@ -30,6 +30,7 @@ const artifacts = core.getMultilineInput('artifacts') //array form
 const isPerformingRelease = core.getInput('perform-release') == 'true' ? true : false
 const currentBranch = process.env.CURRENT_BRANCH
 const preReleaseString = core.getInput('pre-release-string')
+const cosignArtifact = core.getInput('sigstore-sign-artifacts') == 'true' ? true : false;
 const packageInfo = process.env.PACKAGE_INFO ? JSON.parse(process.env.PACKAGE_INFO) : ''
 const manifestInfo = process.env.MANIFEST_INFO ? JSON.parse(process.env.MANIFEST_INFO) : ''
 const skipUpload = core.getBooleanInput('skip-upload')
@@ -66,6 +67,13 @@ if (process.env.DEBUG) {
     utils.printMap(macros)
 }
 
+if (cosignArtifact) {
+    // install cosign
+    for (let artifact of artifacts) {
+        utils.sh(`cosign sign-blob ${artifact} --bundle ${artifact}.bundle --yes`)
+    }
+}
+
 if (isPerformingRelease) {
     var tag = 'v' + macros.get('publishversion')     // when doing release, macros.get('publishversion') will just return a version number 
     if (github.tagExistsRemote(tag)) {
@@ -73,7 +81,7 @@ if (isPerformingRelease) {
     }
 }
 
-makeUploadFileSpec()
+makeUploadFileSpec(cosignArtifact)
 // upload artifacts if provided
 if (!skipUpload && artifacts && artifacts.length > 0) {
     utils.sh_heavyload(`jfrog rt upload --spec ${temporaryUploadSpecName} --threads 6`)
@@ -98,7 +106,7 @@ core.exportVariable('PRE_RELEASE_STRING',preReleaseString)
  * <p>This is a part of publish stage default behavior. If {@link PublishStageArguments#artifacts}
  * is defined, those artifacts will be uploaded to artifactory with this method.</p>
  */
-function makeUploadFileSpec() {
+function makeUploadFileSpec(hasCosignedArtifacts) {
     if (!publishTargetPathPattern.endsWith('/')) {
         publishTargetPathPattern += '/'
     }
@@ -113,7 +121,7 @@ function makeUploadFileSpec() {
                 if (utils.fileExists(file)) {    
                     var targetFileFull = publishTargetPathPattern + publishTargetFilePattern
                     var newMacros = extractArtifactoryUploadTargetFileMacros(file)
-                    debug('After extractArtifactoryUploadTargetFileMacros():')
+                    debug('After file extractArtifactoryUploadTargetFileMacros():')
                     if (process.env.DEBUG) {
                         utils.printMap(newMacros)
                     }
@@ -128,6 +136,30 @@ function makeUploadFileSpec() {
         else {
             console.warn(`File ${fullFilePath} not found`)
         }
+        if (hasCosignedArtifacts) {
+            var fullBundlePath = `${projectRootPath}/${eachArtifact}.bundle`
+            var bundles = glob.sync(fullBundlePath)
+            if (bundles) {
+                bundles.forEach( bundle => {
+                    if (utils.fileExists(bundle)) {
+                        var targetBundleFull = publishTargetPathPattern + publishTargetFilePattern
+                        var bundleMacros = extractArtifactoryUploadTargetFileMacros(bundle)
+                        debug('After cosign bundle extractArtifactoryUploadTargetFileMacros():')
+                        if (process.env.DEBUG) {
+                            utils.printMap(bundleMacros);
+                        }
+                        var mergedBundleMacros = new Map([...macros, ...bundleMacros])
+                        var tb = parseString(targetBundleFull, mergedBundleMacros)
+                        console.log(`- + found ${bundle} -> ${tb}`)
+                        var arrBundle = [{"pattern":bundle, "target": tb}]
+                        uploadSpec['files'] = uploadSpec['files'].concat(arrBundle)
+                    }
+                })
+            }
+        } else {
+            console.warn(`No cosign bundles expected; ignoring.`)
+        }
+        
     })
 
     var json = JSON.stringify(uploadSpec)


### PR DESCRIPTION
Adds the ability to sign artifacts pushed in the publish step with sigstore's `cosign` utility.