### PR TITLE
Don't try to assign bot as PR author

### DIFF
--- a/project-move-item/action.yml
+++ b/project-move-item/action.yml
@@ -52,7 +52,7 @@ runs:
       env:
         GITHUB_TOKEN: ${{ github.token }}
       id: check-author-permissions
-      if: ${{ inputs.assign-author == 'true' && github.event.pull_request && toJSON(github.event.pull_request.assignees) == '[]' }}
+      if: ${{ inputs.assign-author == 'true' && github.event.pull_request && toJSON(github.event.pull_request.assignees) == '[]' && github.event.pull_request.user.type != 'Bot' }}
       shell: bash
 
     - run: gh pr edit ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --add-assignee ${{ github.event.pull_request.user.login }}


### PR DESCRIPTION
This should fix the `project-move-item` workflow failing to assign author for PRs opened by @dependabot (see [example](https://github.com/zowe/vscode-extension-for-zowe/actions/runs/7592524312/job/20681955977))