### PR TITLE
Don't allow GH issue project cards to move backwards

### DIFF
--- a/project-move-item/README.md
+++ b/project-move-item/README.md
@@ -30,10 +30,6 @@ This action updates the Status field of an issue or pull request in a GitHub v2 
 
 **Optional** - For pull requests, set to `true` to assign author to the PR so that the project can be viewed in "Group By: Assignee" mode. Assignee is only added if they are a team member (with write access) and no one else is assigned. Defaults to `false`.
 
-### `locked-status`
-
-**Optional** - For issues, a column name that indicates their status is locked. Issues that have reached this column or one past it will not have their status updated. Defaults to `In Progress` if not specified.
-
 <br />
 
 ## Outputs

--- a/project-move-item/README.md
+++ b/project-move-item/README.md
@@ -30,6 +30,10 @@ This action updates the Status field of an issue or pull request in a GitHub v2 
 
 **Optional** - For pull requests, set to `true` to assign author to the PR so that the project can be viewed in "Group By: Assignee" mode. Assignee is only added if they are a team member (with write access) and no one else is assigned. Defaults to `false`.
 
+### `locked-status`
+
+**Optional** - For issues, a column name that indicates their status is locked. Issues that have reached this column or one past it will not have their status updated. Defaults to `In Progress` if not specified.
+
 <br />
 
 ## Outputs

--- a/project-move-item/action.yml
+++ b/project-move-item/action.yml
@@ -48,7 +48,7 @@ runs:
 
     - run: |
         response=$(gh project field-list ${{ inputs.project-number }} --format json --owner ${{ inputs.project-owner }})
-        echo "statusNames=$(echo $response | jq -r '.fields[] | select(.name == \"Status\") | [ .options[].name ] | join(\",\")')" >> "$GITHUB_OUTPUT"
+        echo "statusNames=$(echo $response | jq -r '.fields[] | select(.name == "Status") | [.options[].name] | join(",")')" >> "$GITHUB_OUTPUT"
       env:
         GITHUB_TOKEN: ${{ inputs.project-token }}
       id: get-project-fields

--- a/project-move-item/action.yml
+++ b/project-move-item/action.yml
@@ -56,11 +56,12 @@ runs:
       shell: bash
 
     - run: |
+        import os
         status_names = "${{ steps.get-project-fields.outputs.statusNames }}".split(",")
         old_status_idx = status_names.index("${{ steps.get-issue-status.outputs.statusName }}")
         new_status_idx = status_names.index("${{ inputs.item-status }}")
         cmp = lambda a, b: (a > b) - (a < b)
-        with open("${{ env.GITHUB_OUTPUT }}", 'a') as f:
+        with open(os.environ["GITHUB_OUTPUT"], 'a') as f:
           f.write("compareResult=" + str(cmp(old_status_idx, new_status_idx)) + "\n")
       id: compare-status-names
       if: ${{ github.event.issue && steps.get-project-fields.outputs.statusNames }}

--- a/project-move-item/action.yml
+++ b/project-move-item/action.yml
@@ -11,6 +11,10 @@ inputs:
   item-status:
     description: 'Column name (Status) to assign to item'
     required: true
+  locked-status:
+    description: 'Column name to keep (items here won''t update their status)'
+    required: false
+    default: 'In Progress'
   project-number:
     description: 'GitHub project number'
     required: true
@@ -43,7 +47,7 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.project-token }}
       id: get-issue-status
-      if: ${{ github.event.issue }}
+      if: ${{ github.event.issue && inputs.locked-status }}
       shell: bash
 
     - run: |
@@ -59,16 +63,15 @@ runs:
         import os
         status_names = "${{ steps.get-project-fields.outputs.statusNames }}".split(",")
         old_status_idx = status_names.index("${{ steps.get-issue-status.outputs.statusName }}")
-        new_status_idx = status_names.index("${{ inputs.item-status }}")
-        cmp = lambda a, b: (a > b) - (a < b)
+        max_status_idx = status_names.index("${{ inputs.locked-status }}")
         with open(os.environ["GITHUB_OUTPUT"], 'a') as f:
-          f.write("compareResult=" + str(cmp(old_status_idx, new_status_idx)) + "\n")
-      id: compare-status-names
+          f.write("isLocked=" + str(old_status_idx >= max_status_idx).lower() + "\n")
+      id: check-status-name
       if: ${{ github.event.issue && steps.get-project-fields.outputs.statusNames }}
       shell: python
 
     - uses: titoportas/update-project-fields@v0.1.0
-      if: ${{ steps.compare-status-names.outputs.compareResult != '1' }}
+      if: ${{ steps.check-status-name.outputs.isLocked != 'true' }}
       with:
         project-url: https://github.com/orgs/${{ inputs.project-owner }}/projects/${{ inputs.project-number }}
         github-token: ${{ inputs.project-token }}

--- a/project-move-item/action.yml
+++ b/project-move-item/action.yml
@@ -56,10 +56,9 @@ runs:
       shell: bash
 
     - run: |
-        import os
-        from difflib import SequenceMatcher
+        import difflib as dl, os
         status_names = "${{ steps.get-project-fields.outputs.statusNames }}".split(",")
-        find_similar = lambda xs, x: next(y for y in xs if SequenceMatcher(None, x, y).ratio() > 0.5)
+        find_similar = lambda xs, x: next(i for i, y in enumerate(xs) if dl.SequenceMatcher(None, x, y).ratio() > 0.5)
         old_status_idx = find_similar(status_names, "${{ steps.get-issue-status.outputs.statusName }}")
         new_status_idx = find_similar(status_names, "${{ inputs.item-status }}")
         cmp = lambda a, b: (a > b) - (a < b)

--- a/project-move-item/action.yml
+++ b/project-move-item/action.yml
@@ -52,7 +52,7 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.project-token }}
       id: get-project-fields
-      if: ${{ github.event.issue && steps.get-issue-status.outputs.statusName != 'null' }}
+      if: ${{ github.event.issue && steps.get-issue-status.outputs.statusName }}
       shell: bash
 
     - run: |

--- a/project-move-item/action.yml
+++ b/project-move-item/action.yml
@@ -11,10 +11,6 @@ inputs:
   item-status:
     description: 'Column name (Status) to assign to item'
     required: true
-  locked-status:
-    description: 'Column name to keep (items here won''t update their status)'
-    required: false
-    default: 'In Progress'
   project-number:
     description: 'GitHub project number'
     required: true
@@ -47,7 +43,7 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.project-token }}
       id: get-issue-status
-      if: ${{ github.event.issue && inputs.locked-status }}
+      if: ${{ github.event.issue }}
       shell: bash
 
     - run: |
@@ -61,17 +57,20 @@ runs:
 
     - run: |
         import os
+        from difflib import SequenceMatcher
         status_names = "${{ steps.get-project-fields.outputs.statusNames }}".split(",")
-        old_status_idx = status_names.index("${{ steps.get-issue-status.outputs.statusName }}")
-        max_status_idx = status_names.index("${{ inputs.locked-status }}")
+        find_similar = lambda xs, x: next(y for y in xs if SequenceMatcher(None, x, y).ratio() > 0.5)
+        old_status_idx = find_similar(status_names, "${{ steps.get-issue-status.outputs.statusName }}")
+        new_status_idx = find_similar(status_names, "${{ inputs.item-status }}")
+        cmp = lambda a, b: (a > b) - (a < b)
         with open(os.environ["GITHUB_OUTPUT"], 'a') as f:
-          f.write("isLocked=" + str(old_status_idx >= max_status_idx).lower() + "\n")
-      id: check-status-name
+          f.write("compareResult=" + str(cmp(old_status_idx, new_status_idx)) + "\n")
+      id: compare-status-names
       if: ${{ github.event.issue && steps.get-project-fields.outputs.statusNames }}
       shell: python
 
     - uses: titoportas/update-project-fields@v0.1.0
-      if: ${{ steps.check-status-name.outputs.isLocked != 'true' }}
+      if: ${{ steps.compare-status-names.outputs.compareResult != '1' }}
       with:
         project-url: https://github.com/orgs/${{ inputs.project-owner }}/projects/${{ inputs.project-number }}
         github-token: ${{ inputs.project-token }}

--- a/project-move-item/action.yml
+++ b/project-move-item/action.yml
@@ -37,7 +37,37 @@ runs:
       id: add-to-project
       shell: bash
 
+    - run: |
+        response=$(gh issue view ${{ github.event.issue.number }} --repo ${{ github.repository }} --json projectItems)
+        echo "statusName=$(echo $response | jq -r '.projectItems[] | .status.name')" >> "$GITHUB_OUTPUT"
+      env:
+        GITHUB_TOKEN: ${{ inputs.project-token }}
+      id: get-issue-status
+      if: ${{ github.event.issue }}
+      shell: bash
+
+    - run: |
+        response=$(gh project field-list ${{ inputs.project-number }} --format json --owner ${{ inputs.project-owner }})
+        echo "statusNames=$(echo $response | jq -r '.fields[] | select(.name == \"Status\") | [ .options[].name ] | join(\",\")')" >> "$GITHUB_OUTPUT"
+      env:
+        GITHUB_TOKEN: ${{ inputs.project-token }}
+      id: get-project-fields
+      if: ${{ github.event.issue && steps.get-issue-status.outputs.statusName != 'null' }}
+      shell: bash
+
+    - run: |
+        status_names = "${{ steps.get-project-fields.outputs.statusNames }}".split(",")
+        old_status_idx = status_names.index("${{ steps.get-issue-status.outputs.statusName }}")
+        new_status_idx = status_names.index("${{ inputs.item-status }}")
+        cmp = lambda a, b: (a > b) - (a < b)
+        with open("${{ env.GITHUB_OUTPUT }}", 'a') as f:
+          f.write("compareResult=" + str(cmp(old_status_idx, new_status_idx)) + "\n")
+      id: compare-status-names
+      if: ${{ github.event.issue && steps.get-project-fields.outputs.statusNames }}
+      shell: python
+
     - uses: titoportas/update-project-fields@v0.1.0
+      if: ${{ steps.compare-status-names.outputs.compareResult != '1' }}
       with:
         project-url: https://github.com/orgs/${{ inputs.project-owner }}/projects/${{ inputs.project-number }}
         github-token: ${{ inputs.project-token }}


### PR DESCRIPTION
When a priority label is assigned to a GitHub issue that has already been moved to the In Progress column, then the workflow should not change the issue's status.

I've tested the workflow changes with a fork of ZE and a private GH project 😋 