### PR TITLE
feat: Merge-by table and comments action

### DIFF
--- a/merge-by/action.yml
+++ b/merge-by/action.yml
@@ -10,15 +10,20 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v3
+    - uses: pnpm/action-setup@v4
+      with:
+        version: 8
+        run_install: false
+
     - uses: actions/setup-node@v4
       with:
         node-version: 22
-        cache: 'npm'
+        cache: 'pnpm'
 
     - name: Install dependencies
-      run: npm install
-      shell: bash
+      run: pnpm install
+      shell: "bash"
 
     - uses: actions/github-script@v7
       if: ${{ inputs.operation == 'build-table' }}

--- a/merge-by/action.yml
+++ b/merge-by/action.yml
@@ -12,10 +12,6 @@ runs:
   steps:
     - run: mkdir merge-by-pkg && cd merge-by-pkg && npm init -y
       shell: "sh"
-    - uses: actions/setup-node@v4
-      with:
-        node-version: 'lts/*'
-        cache: 'npm'
     - run: npm install dayjs
       shell: "sh"
     - uses: actions/github-script@v7

--- a/merge-by/action.yml
+++ b/merge-by/action.yml
@@ -23,7 +23,7 @@ runs:
 
     - name: Install dependencies
       run: pnpm install && pnpm install -g dayjs
-      shell: "bash"
+      shell: "sh"
 
     - uses: actions/github-script@v7
       if: ${{ inputs.operation == 'build-table' }}

--- a/merge-by/action.yml
+++ b/merge-by/action.yml
@@ -26,7 +26,7 @@ runs:
       with:
         script: |
             const script = require("${{ github.action_path }}/scripts/build-table-and-notify.js");
-            await script({ github, context });
+            await script({ github, context, require });
     - uses: actions/github-script@v7
       if: ${{ inputs.operation == 'bump-dates' }}
       with:

--- a/merge-by/action.yml
+++ b/merge-by/action.yml
@@ -3,7 +3,7 @@ description: "Tracks the status of ongoing pull requests and provides expected d
 
 inputs:
   operation:
-    description: 'The operation to run as part of this action (table, bump-dates)'
+    description: 'The operation to run as part of this action (build-table, bump-dates)'
     required: true
     default: 'build-table'
 

--- a/merge-by/action.yml
+++ b/merge-by/action.yml
@@ -10,20 +10,20 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v3
-    - uses: pnpm/action-setup@v4
-      with:
-        version: 8
-        run_install: false
+    - name: Checkout
+      uses: actions/checkout@v3
 
-    - uses: actions/setup-node@v4
+    - name: Install Node.js
+      uses: actions/setup-node@v4
       with:
-        node-version: 22
+        node-version: 20
         cache: 'pnpm'
 
-    - name: Install dependencies
-      run: pnpm install && pnpm install -g dayjs
-      shell: "sh"
+    - name: Install pnpm
+      uses: pnpm/action-setup@v4
+      with:
+        version: 8
+        run_install: true
 
     - uses: actions/github-script@v7
       if: ${{ inputs.operation == 'build-table' }}

--- a/merge-by/action.yml
+++ b/merge-by/action.yml
@@ -10,6 +10,8 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - run: mkdir merge-by-pkg && cd merge-by-pkg && npm init -y
+      shell: "sh"
     - uses: actions/setup-node@v4
       with:
         node-version: 'lts/*'

--- a/merge-by/action.yml
+++ b/merge-by/action.yml
@@ -10,7 +10,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
       with:
         node-version: 'lts/*'

--- a/merge-by/action.yml
+++ b/merge-by/action.yml
@@ -13,17 +13,20 @@ runs:
     - name: Checkout
       uses: actions/checkout@v3
 
+    - name: Install pnpm
+      uses: pnpm/action-setup@v4
+      with:
+        version: 8
+        run_install: false
+
     - name: Install Node.js
       uses: actions/setup-node@v4
       with:
         node-version: 20
         cache: 'pnpm'
 
-    - name: Install pnpm
-      uses: pnpm/action-setup@v4
-      with:
-        version: 8
-        run_install: true
+    - run: pnpm install
+      shell: "sh"
 
     - uses: actions/github-script@v7
       if: ${{ inputs.operation == 'build-table' }}

--- a/merge-by/action.yml
+++ b/merge-by/action.yml
@@ -29,14 +29,14 @@ runs:
       if: ${{ inputs.operation == 'build-table' }}
       with:
         script: |
-            const script = require("./merge-by/scripts/build-table-and-notify.js");
+            const script = require("${{ github.action_path }}/scripts/build-table-and-notify.js");
             await script({ github, context });
 
     - uses: actions/github-script@v7
       if: ${{ inputs.operation == 'bump-dates' }}
       with:
         script: |
-            const script = require("./merge-by/scripts/bump-dates.js");
+            const script = require("${{ github.action_path }}/scripts/bump-dates.js");
             await script({ github, context });
 
           

--- a/merge-by/action.yml
+++ b/merge-by/action.yml
@@ -10,31 +10,23 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-
-    - name: Install pnpm
-      uses: pnpm/action-setup@v4
+    - uses: actions/checkout@v3
+    - uses: pnpm/action-setup@v4
       with:
         version: 8
         run_install: false
-
-    - name: Install Node.js
-      uses: actions/setup-node@v4
+    - uses: actions/setup-node@v4
       with:
         node-version: 20
         cache: 'pnpm'
-
     - run: pnpm install
       shell: "sh"
-
     - uses: actions/github-script@v7
       if: ${{ inputs.operation == 'build-table' }}
       with:
         script: |
             const script = require("${{ github.action_path }}/scripts/build-table-and-notify.js");
             await script({ github, context });
-
     - uses: actions/github-script@v7
       if: ${{ inputs.operation == 'bump-dates' }}
       with:

--- a/merge-by/action.yml
+++ b/merge-by/action.yml
@@ -10,9 +10,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - run: mkdir merge-by-pkg && cd merge-by-pkg && npm init -y
-      shell: "sh"
-    - run: npm install dayjs
+    - run: npm install -g dayjs
       shell: "sh"
     - uses: actions/github-script@v7
       if: ${{ inputs.operation == 'build-table' }}

--- a/merge-by/action.yml
+++ b/merge-by/action.yml
@@ -22,7 +22,7 @@ runs:
         cache: 'pnpm'
 
     - name: Install dependencies
-      run: pnpm install
+      run: pnpm install && pnpm install -g dayjs
       shell: "bash"
 
     - uses: actions/github-script@v7

--- a/merge-by/action.yml
+++ b/merge-by/action.yml
@@ -1,0 +1,37 @@
+name: "Merge-by"
+description: "Tracks the status of ongoing pull requests and provides expected dates for merging"
+
+inputs:
+  operation:
+    description: 'The operation to run as part of this action (table, bump-dates)'
+    required: true
+    default: 'table'
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 22
+        cache: 'npm'
+
+    - name: Install dependencies
+      run: npm install
+      shell: bash
+
+    - uses: actions/github-script@v7
+      if: ${{ inputs.operation == 'table' }}
+      with:
+        script: |
+            const script = require("./merge-by/scripts/build-table-and-notify.js");
+            await script({ github, context });
+
+    - uses: actions/github-script@v7
+      if: ${{ inputs.operation == 'bump-dates' }}
+      with:
+        script: |
+            const script = require("./merge-by/scripts/bump-dates.js");
+            await script({ github, context });
+
+          

--- a/merge-by/action.yml
+++ b/merge-by/action.yml
@@ -5,7 +5,7 @@ inputs:
   operation:
     description: 'The operation to run as part of this action (table, bump-dates)'
     required: true
-    default: 'table'
+    default: 'build-table'
 
 runs:
   using: "composite"
@@ -21,7 +21,7 @@ runs:
       shell: bash
 
     - uses: actions/github-script@v7
-      if: ${{ inputs.operation == 'table' }}
+      if: ${{ inputs.operation == 'build-table' }}
       with:
         script: |
             const script = require("./merge-by/scripts/build-table-and-notify.js");

--- a/merge-by/action.yml
+++ b/merge-by/action.yml
@@ -10,16 +10,12 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v3
-    - uses: pnpm/action-setup@v4
-      with:
-        version: 8
-        run_install: false
+    - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
       with:
-        node-version: 20
-        cache: 'pnpm'
-    - run: pnpm install
+        node-version: 'lts/*'
+        cache: 'npm'
+    - run: npm install dayjs
       shell: "sh"
     - uses: actions/github-script@v7
       if: ${{ inputs.operation == 'build-table' }}

--- a/merge-by/scripts/build-table-and-notify.js
+++ b/merge-by/scripts/build-table-and-notify.js
@@ -164,7 +164,7 @@ module.exports = async ({ github, context, require }) => {
     github,
     owner,
     repo,
-    reverse,
+    reverse: true
   });
   // Look over existing PRs, grab all PRs with a merge-by date <= 1w from now, and update the issue with the new table
   await scanPRsAndUpdateTable({ github, owner, pullRequests, repo });

--- a/merge-by/scripts/build-table-and-notify.js
+++ b/merge-by/scripts/build-table-and-notify.js
@@ -1,18 +1,13 @@
 import { QUERIES, MUTATIONS } from "./graphql";
 import { getPullRequests } from "./promises";
 
+/** @typedef {import("./promises").PullInfo} PullInfo */
+
 /**
  * Builds a row for the Markdown table given the GitHub repo owner, repo name and pull request.
  * @param {string} owner The owner of the repository (user or organization)
  * @param {string} repo The name of the repository on GitHub
- * @param {Object} pr The pull request data to use for the table row
- * @param {number} pr.number The number for the pull request
- * @param {string} pr.author The author of the pull request
- * @param {string} pr.title The title of the pull request
- * @param {boolean} pr.hasReviews Whether the pull request has 2 or more approvals
- * @param {boolean} pr.mergeable Whether the pull request is able to be merged
- * @param {Object[]} pr.reviewers The list of requested reviewers for the pull request
- * @param {string} pr.mergeBy (optional) The merge-by date for the pull request
+ * @param {PullInfo} pr The pull request data to use for the table row
  * @returns
  */
 const buildTableRow = (owner, repo, pr) =>
@@ -37,13 +32,7 @@ const DISCUSSION_NAME = "PR Status List";
  *
  * @param {Object} github The OctoKit/rest.js API for making requests to GitHub
  * @param {string} owner The owner of the repository (user or organization)
- * @param {Object[]} pullRequests The list of pull requests to include in the table
- * @param {number} pullRequests[].number The number for the pull request
- * @param {string} pullRequests[].author The author of the pull request
- * @param {string} pullRequests[].title The title of the pull request
- * @param {boolean} pullRequests[].hasReviews Whether the pull request has 2 or more approvals
- * @param {boolean} pullRequests[].mergeable Whether the pull request is able to be merged
- * @param {Object[]} pullRequests[].reviewers The list of requested reviewers for the pull request
+ * @param {PullInfo[]} pullRequests The list of pull requests to include in the table
  * @param {string} pullRequests[].mergeBy (optional) The merge-by date for the pull request
  * @param {string} repo The name of the repository on GitHub
  */
@@ -94,13 +83,7 @@ const scanPRsAndUpdateTable = async ({ github, owner, pullRequests, repo }) => {
  * @param {Object} dayJs Day.js exports for manipulating/querying time differences
  * @param {Object} github The OctoKit/rest.js API for making requests to GitHub
  * @param {string} owner The owner of the repo (user or organization)
- * @param {Object[]} pullRequests The list of pull requests to include in the table
- * @param {string} pullRequests[].number The number for the pull request
- * @param {string} pullRequests[].author The author of the pull request
- * @param {string} pullRequests[].title The title of the pull request
- * @param {string} pullRequests[].mergeable Whether the pull request is able to be merged
- * @param {string} pullRequests[].reviewers The list of requested reviewers for the pull request
- * @param {string} pullRequests[].mergeBy (optional) The merge-by date for the pull request
+ * @param {PullInfo[]} pullRequests The list of pull requests to include in the table
  * @param {string} repo The name of the GitHub repo
  * @param {Object} today Today's date represented as a Day.js object
  */

--- a/merge-by/scripts/build-table-and-notify.js
+++ b/merge-by/scripts/build-table-and-notify.js
@@ -169,7 +169,7 @@ const notifyUsers = async ({
  */
 const fetchPullRequests = async ({ dayJs, github, owner, repo, today }) => {
   const nextWeek = today.add(7, "day");
-  return (await Promise.all(getPullRequests({ dayJs, github })))
+  return getPullRequests({ dayJs, github })
     .filter((pr) => {
       if (pr.mergeBy == null) {
         return true;

--- a/merge-by/scripts/build-table-and-notify.js
+++ b/merge-by/scripts/build-table-and-notify.js
@@ -1,5 +1,5 @@
-import { QUERIES, MUTATIONS } from "./graphql";
-import { getPullRequests } from "./promises";
+const { QUERIES, MUTATIONS } = require("./graphql");
+const { getPullRequests } = require("./promises");
 
 /** @typedef {import("./promises").PullInfo} PullInfo */
 

--- a/merge-by/scripts/build-table-and-notify.js
+++ b/merge-by/scripts/build-table-and-notify.js
@@ -55,8 +55,8 @@ const DISCUSSION_NAME = "PR Status List";
  * @param {string} pullRequests[].mergeBy (optional) The merge-by date for the pull request
  * @param {string} repo The name of the repository on GitHub
  */
+// Build a table using Markdown to post within the issue
 const scanPRsAndUpdateTable = async ({ github, owner, pullRequests, repo }) => {
-  // Build a table using Markdown to post within the issue
   const body = `${TABLE_HEADER}\n${pullRequests
     .map((pr) => buildTableRow(owner, repo, pr))
     .join("\n")}`;
@@ -168,17 +168,7 @@ const notifyUsers = async ({
  * @param {Object} today Today's date, represented as a day.js object
  */
 const fetchPullRequests = async ({ dayJs, github, owner, repo, today }) => {
-  const nextWeek = today.add(7, "day");
   return (await getPullRequests({ dayJs, github, owner, repo }))
-    .filter((pr) => {
-      if (pr.mergeBy == null) {
-        return true;
-      }
-
-      // Filter out any PRs that have merge-by dates > 1 week from now
-      const mergeByDate = dayJs(pr.mergeBy);
-      return nextWeek.diff(mergeByDate, "day") <= 7;
-    })
     .reverse();
 };
 

--- a/merge-by/scripts/build-table-and-notify.js
+++ b/merge-by/scripts/build-table-and-notify.js
@@ -1,0 +1,217 @@
+/**
+ * Builds a row for the Markdown table given the GitHub repo owner, repo name and pull request. 
+ * @param {string} owner The owner of the repository (user or organization)
+ * @param {string} repo The name of the repository on GitHub
+ * @param {Object} pr The pull request data to use for the table row
+  * @param {number} pr.number The number for the pull request
+  * @param {string} pr.author The author of the pull request
+  * @param {string} pr.title The title of the pull request
+  * @param {boolean} pr.hasReviews Whether the pull request has 2 or more approvals
+  * @param {boolean} pr.mergeable Whether the pull request is able to be merged
+  * @param {Object[]} pr.reviewers The list of requested reviewers for the pull request
+  * @param {string} pr.mergeBy (optional) The merge-by date for the pull request
+ * @returns 
+ */
+const buildTableRow = (owner, repo, pr) =>
+  `| [#${pr.number}](https://github.com/${owner}/${repo}/pull/${pr.number}) | [**${pr.title.trim()}**](https://github.com/${owner}/${repo}/pull/${pr.number}) | ${pr.author} | ${pr.mergeBy ?? "N/A"} | ${pr.hasReviews && pr.mergeable !== false ? ":white_check_mark:" : ":white_large_square:"} |`;
+
+const tableHeader = `
+| # | Title | Author | Merge by | Ready to merge? |
+| - | ----- | ------ | ------------- | -------------- |`;
+
+/**
+ * Scans PRs and builds a table using Markdown. Updates an issue or creates a new one with the table.
+ * 
+ * @param {Object} github The OctoKit/rest.js API for making requests to GitHub
+ * @param {string} owner The owner of the repository (user or organization)
+ * @param {Object[]} pullRequests The list of pull requests to include in the table
+  * @param {number} pullRequests[].number The number for the pull request
+  * @param {string} pullRequests[].author The author of the pull request
+  * @param {string} pullRequests[].title The title of the pull request
+  * @param {boolean} pullRequests[].hasReviews Whether the pull request has 2 or more approvals
+  * @param {boolean} pullRequests[].mergeable Whether the pull request is able to be merged
+  * @param {Object[]} pullRequests[].reviewers The list of requested reviewers for the pull request
+  * @param {string} pullRequests[].mergeBy (optional) The merge-by date for the pull request
+ * @param {string} repo The name of the repository on GitHub
+ */
+const scanPRsAndUpdateTable = async ({ github, owner, pullRequests, repo }) => {
+  // Build a table using Markdown to post within the issue
+  const body = `${tableHeader}\n${pullRequests.map((pr) => buildTableRow(owner, repo, pr)).join("\n")}`;
+  
+  const graphqlQuery = `query($owner:String!, $repo:String!) {
+        repository(owner:$owner, name:$repo) {
+            id
+
+            discussionCategories(first: 100) {
+                nodes {
+                    id
+                    name
+                }
+            }
+
+            discussions(first: 100) {
+                nodes {
+                    id
+                    body
+                    title
+                }
+            }
+        }
+    }`;
+
+  const discussionsQuery = await github.graphql(graphqlQuery, {
+    owner,
+    repo,
+  });
+  const discussion = discussionsQuery?.repository?.discussions?.nodes?.find((d) => d.title === "PR Status List");
+
+  if (discussion != null) {
+    const mutation = `mutation($input:UpdateDiscussionInput!) {
+      updateDiscussion(input: $input) {
+        discussion {
+          id
+        }
+      }
+    }`
+    await github.graphql(mutation, {
+      input: {
+        discussionId: discussion.id,
+        body,
+      }
+    });
+  } else {
+    const mutation = `mutation($input:CreateDiscussionInput!) {
+      createDiscussion(input: $input) {
+        discussion {
+          id
+        }
+      }
+    }`;
+    const generalCategory = discussionsQuery.repository?.discussionCategories?.nodes?.find((cat) => cat.name === "General");
+    await github.graphql(mutation, {
+      input: {
+        categoryId: generalCategory.id,
+        repositoryId: discussionsQuery?.repository?.id,
+        body,
+        title: "PR Status List"
+      }
+    });
+  }
+}
+
+/**
+ * Notifies users for PRs that have a merge-by date <24 hours from now.
+ * 
+ * @param {Object} dayJs Day.js exports for manipulating/querying time differences
+ * @param {Object} github The OctoKit/rest.js API for making requests to GitHub
+ * @param {string} owner The owner of the repo (user or organization)
+ * @param {Object[]} pullRequests The list of pull requests to include in the table
+  * @param {string} pullRequests[].number The number for the pull request
+  * @param {string} pullRequests[].author The author of the pull request
+  * @param {string} pullRequests[].title The title of the pull request
+  * @param {string} pullRequests[].mergeable Whether the pull request is able to be merged
+  * @param {string} pullRequests[].reviewers The list of requested reviewers for the pull request
+  * @param {string} pullRequests[].mergeBy (optional) The merge-by date for the pull request
+ * @param {string} repo The name of the GitHub repo
+ * @param {Object} today Today's date represented as a Day.js object
+ */
+const notifyUsers = async ({ dayJs, github, owner, pullRequests, repo, today }) => {
+  const prsCloseToMergeDate = pullRequests.filter((pr) => {
+    if (pr.mergeBy == null) {
+      return false;
+    }
+
+    // Filter out any PRs that don't have merge-by dates within a day from now
+    const mergeByDate = dayJs(pr.mergeBy);
+    return mergeByDate.diff(today, "day") <= 1;
+  });
+
+  for (const pr of prsCloseToMergeDate) {
+    const comments = (await github.rest.issues.listComments({ owner, repo, issue_number: pr.number })).data;
+    // Try to find the reminder comment
+    const existingComment = comments?.find((comment) =>
+      comment.user.login === "github-actions[bot]" && comment.body.includes("**Reminder:** This pull request has a merge-by date coming up within the next 24 hours. Please review this PR as soon as possible."));
+
+    if (existingComment != null) {
+      continue;
+    }
+
+    // Make a comment on the PR and tag reviewers
+    const body = `**Reminder:** This pull request has a merge-by date coming up within the next 24 hours. Please review this PR as soon as possible.\n\n${pr.reviewers.map((r) => `@${r.login}`).join(" ")}`
+    await github.rest.issues.createComment({
+      owner,
+      repo,
+      issue_number: pr.number,
+      body
+    });
+  }
+};
+
+/**
+ * Fetches PRs with a merge-by date < 1 week from now.
+ * 
+ * @param {Object} dayJs Day.js exports for manipulating/querying time differences
+ * @param {Object} github The OctoKit/rest.js API for making requests to GitHub
+ * @param {string} owner The owner of the repository (user or organization)
+ * @param {string} repo The name of the repository on GitHub
+ * @param {Object} today Today's date, represented as a day.js object
+ */
+const fetchPullRequests = async ({ dayJs, github, owner, repo, today }) => {
+  const nextWeek = today.add(7, "day");
+  return (await Promise.all((await github.rest.pulls.list({
+    owner,
+    repo,
+    state: "open"
+  }))?.data.filter((pr) => !pr.draft)
+    .map(async (pr) => {
+      const comments = (await github.rest.issues.listComments({ owner, repo, issue_number: pr.number })).data;
+      // Attempt to parse the merge-by date from the bot comment
+      const existingComment = comments?.find((comment) =>
+        comment.user.login === "github-actions[bot]" && comment.body.includes("**📅 Suggested merge-by date:"));
+
+      const reviews = (await github.rest.pulls.listReviews({
+        owner,
+        repo,
+        pull_number: pr.number,
+      })).data;
+
+      const hasTwoReviews = reviews.reduce((all, review) => review.state === "APPROVED" ? all + 1 : all, 0) >= 2;
+
+      // Filter out reviewers if they have already reviewed and approved the pull request
+      const reviewersNotApproved = pr.requested_reviewers
+        .filter((reviewer) => 
+          reviews.find((review) => review.state === "APPROVED" && reviewer.login === review.user.login) == null);
+
+      return {
+        number: pr.number,
+        title: pr.title,
+        author: pr.user.login,
+        hasReviews: hasTwoReviews,
+        mergeable: pr.mergeable,
+        reviewers: reviewersNotApproved,
+        mergeBy: existingComment?.body.substring(existingComment.body.lastIndexOf("*") + 1).trim()
+      };
+    }))).filter((pr) => {
+      if (pr.mergeBy == null) {
+        return true;
+      }
+
+      // Filter out any PRs that have merge-by dates > 1 week from now
+      const mergeByDate = dayJs(pr.mergeBy);
+      return nextWeek.diff(mergeByDate, "day") <= 7;
+    }).reverse();
+}
+
+module.exports = async ({ github, context }) => {
+  const dayJs = require("dayjs");
+  const today = dayJs();
+  const owner = context.repo.owner;
+  const repo = context.repo.repo;
+  const pullRequests = await fetchPullRequests({ dayJs, github, owner, repo, today });
+  // Look over existing PRs, grab all PRs with a merge-by date <= 1w from now, and update the issue with the new table
+  await scanPRsAndUpdateTable({ github, owner, pullRequests, repo });
+  // Notify users for PRs with merge-by dates coming up within 24hrs from now
+  if (context.eventName === "schedule") {
+    await notifyUsers({ dayJs, github, owner, pullRequests, repo, today });
+  }
+}

--- a/merge-by/scripts/build-table-and-notify.js
+++ b/merge-by/scripts/build-table-and-notify.js
@@ -1,121 +1,113 @@
+import { QUERIES, MUTATIONS } from "./graphql";
+
 /**
- * Builds a row for the Markdown table given the GitHub repo owner, repo name and pull request. 
+ * Builds a row for the Markdown table given the GitHub repo owner, repo name and pull request.
  * @param {string} owner The owner of the repository (user or organization)
  * @param {string} repo The name of the repository on GitHub
  * @param {Object} pr The pull request data to use for the table row
-  * @param {number} pr.number The number for the pull request
-  * @param {string} pr.author The author of the pull request
-  * @param {string} pr.title The title of the pull request
-  * @param {boolean} pr.hasReviews Whether the pull request has 2 or more approvals
-  * @param {boolean} pr.mergeable Whether the pull request is able to be merged
-  * @param {Object[]} pr.reviewers The list of requested reviewers for the pull request
-  * @param {string} pr.mergeBy (optional) The merge-by date for the pull request
- * @returns 
+ * @param {number} pr.number The number for the pull request
+ * @param {string} pr.author The author of the pull request
+ * @param {string} pr.title The title of the pull request
+ * @param {boolean} pr.hasReviews Whether the pull request has 2 or more approvals
+ * @param {boolean} pr.mergeable Whether the pull request is able to be merged
+ * @param {Object[]} pr.reviewers The list of requested reviewers for the pull request
+ * @param {string} pr.mergeBy (optional) The merge-by date for the pull request
+ * @returns
  */
 const buildTableRow = (owner, repo, pr) =>
-  `| [#${pr.number}](https://github.com/${owner}/${repo}/pull/${pr.number}) | [**${pr.title.trim()}**](https://github.com/${owner}/${repo}/pull/${pr.number}) | ${pr.author} | ${pr.mergeBy ?? "N/A"} | ${pr.hasReviews && pr.mergeable !== false ? ":white_check_mark:" : ":white_large_square:"} |`;
+  `| [#${pr.number}](https://github.com/${owner}/${repo}/pull/${pr.number
+  }) | [**${pr.title.trim()}**](https://github.com/${owner}/${repo}/pull/${pr.number
+  }) | ${pr.author} | ${pr.mergeBy ?? "N/A"} | ${pr.hasReviews && pr.mergeable !== false
+    ? ":white_check_mark:"
+    : ":white_large_square:"
+  } |`;
 
-const tableHeader = `
+const TABLE_HEADER = `
 | # | Title | Author | Merge by | Ready to merge? |
 | - | ----- | ------ | ------------- | -------------- |`;
 
+const DISCUSSION_NAME = "PR Status List";
+
 /**
  * Scans PRs and builds a table using Markdown. Updates an issue or creates a new one with the table.
- * 
+ *
  * @param {Object} github The OctoKit/rest.js API for making requests to GitHub
  * @param {string} owner The owner of the repository (user or organization)
  * @param {Object[]} pullRequests The list of pull requests to include in the table
-  * @param {number} pullRequests[].number The number for the pull request
-  * @param {string} pullRequests[].author The author of the pull request
-  * @param {string} pullRequests[].title The title of the pull request
-  * @param {boolean} pullRequests[].hasReviews Whether the pull request has 2 or more approvals
-  * @param {boolean} pullRequests[].mergeable Whether the pull request is able to be merged
-  * @param {Object[]} pullRequests[].reviewers The list of requested reviewers for the pull request
-  * @param {string} pullRequests[].mergeBy (optional) The merge-by date for the pull request
+ * @param {number} pullRequests[].number The number for the pull request
+ * @param {string} pullRequests[].author The author of the pull request
+ * @param {string} pullRequests[].title The title of the pull request
+ * @param {boolean} pullRequests[].hasReviews Whether the pull request has 2 or more approvals
+ * @param {boolean} pullRequests[].mergeable Whether the pull request is able to be merged
+ * @param {Object[]} pullRequests[].reviewers The list of requested reviewers for the pull request
+ * @param {string} pullRequests[].mergeBy (optional) The merge-by date for the pull request
  * @param {string} repo The name of the repository on GitHub
  */
 const scanPRsAndUpdateTable = async ({ github, owner, pullRequests, repo }) => {
   // Build a table using Markdown to post within the issue
-  const body = `${tableHeader}\n${pullRequests.map((pr) => buildTableRow(owner, repo, pr)).join("\n")}`;
-  
-  const graphqlQuery = `query($owner:String!, $repo:String!) {
-        repository(owner:$owner, name:$repo) {
-            id
+  const body = `${TABLE_HEADER}\n${pullRequests
+    .map((pr) => buildTableRow(owner, repo, pr))
+    .join("\n")}`;
 
-            discussionCategories(first: 100) {
-                nodes {
-                    id
-                    name
-                }
-            }
-
-            discussions(first: 100) {
-                nodes {
-                    id
-                    body
-                    title
-                }
-            }
-        }
-    }`;
-
-  const discussionsQuery = await github.graphql(graphqlQuery, {
+  // Search through discussions for the title "PR Status List"
+  const discussionsQuery = await github.graphql(QUERIES.GET_DISCUSSIONS, {
     owner,
     repo,
   });
-  const discussion = discussionsQuery?.repository?.discussions?.nodes?.find((d) => d.title === "PR Status List");
+  const discussion = discussionsQuery?.repository?.discussions?.nodes?.find(
+    (d) => d.title === DISCUSSION_NAME
+  );
 
   if (discussion != null) {
-    const mutation = `mutation($input:UpdateDiscussionInput!) {
-      updateDiscussion(input: $input) {
-        discussion {
-          id
-        }
-      }
-    }`
-    await github.graphql(mutation, {
+    // Create a discussion for the PR statuses since one does not exist.
+    await github.graphql(MUTATIONS.UPDATE_DISCUSSION, {
       input: {
         discussionId: discussion.id,
         body,
-      }
+      },
     });
   } else {
-    const mutation = `mutation($input:CreateDiscussionInput!) {
-      createDiscussion(input: $input) {
-        discussion {
-          id
-        }
-      }
-    }`;
-    const generalCategory = discussionsQuery.repository?.discussionCategories?.nodes?.find((cat) => cat.name === "General");
-    await github.graphql(mutation, {
+    // Update the existing discussion with the new PR statuses.
+    // The discussion is in the "General" category.
+    const generalCategory =
+      discussionsQuery.repository?.discussionCategories?.nodes?.find(
+        (cat) => cat.name === "General"
+      );
+    await github.graphql(MUTATIONS.CREATE_DISCUSSION, {
       input: {
         categoryId: generalCategory.id,
         repositoryId: discussionsQuery?.repository?.id,
         body,
-        title: "PR Status List"
-      }
+        title: DISCUSSION_NAME,
+      },
     });
   }
-}
+};
 
 /**
  * Notifies users for PRs that have a merge-by date <24 hours from now.
- * 
+ *
  * @param {Object} dayJs Day.js exports for manipulating/querying time differences
  * @param {Object} github The OctoKit/rest.js API for making requests to GitHub
  * @param {string} owner The owner of the repo (user or organization)
  * @param {Object[]} pullRequests The list of pull requests to include in the table
-  * @param {string} pullRequests[].number The number for the pull request
-  * @param {string} pullRequests[].author The author of the pull request
-  * @param {string} pullRequests[].title The title of the pull request
-  * @param {string} pullRequests[].mergeable Whether the pull request is able to be merged
-  * @param {string} pullRequests[].reviewers The list of requested reviewers for the pull request
-  * @param {string} pullRequests[].mergeBy (optional) The merge-by date for the pull request
+ * @param {string} pullRequests[].number The number for the pull request
+ * @param {string} pullRequests[].author The author of the pull request
+ * @param {string} pullRequests[].title The title of the pull request
+ * @param {string} pullRequests[].mergeable Whether the pull request is able to be merged
+ * @param {string} pullRequests[].reviewers The list of requested reviewers for the pull request
+ * @param {string} pullRequests[].mergeBy (optional) The merge-by date for the pull request
  * @param {string} repo The name of the GitHub repo
  * @param {Object} today Today's date represented as a Day.js object
  */
-const notifyUsers = async ({ dayJs, github, owner, pullRequests, repo, today }) => {
+const notifyUsers = async ({
+  dayJs,
+  github,
+  owner,
+  pullRequests,
+  repo,
+  today,
+}) => {
   const prsCloseToMergeDate = pullRequests.filter((pr) => {
     if (pr.mergeBy == null) {
       return false;
@@ -127,29 +119,42 @@ const notifyUsers = async ({ dayJs, github, owner, pullRequests, repo, today }) 
   });
 
   for (const pr of prsCloseToMergeDate) {
-    const comments = (await github.rest.issues.listComments({ owner, repo, issue_number: pr.number })).data;
+    const comments = (
+      await github.rest.issues.listComments({
+        owner,
+        repo,
+        issue_number: pr.number,
+      })
+    ).data;
     // Try to find the reminder comment
-    const existingComment = comments?.find((comment) =>
-      comment.user.login === "github-actions[bot]" && comment.body.includes("**Reminder:** This pull request has a merge-by date coming up within the next 24 hours. Please review this PR as soon as possible."));
+    const existingComment = comments?.find(
+      (comment) =>
+        comment.user.login === "github-actions[bot]" &&
+        comment.body.includes(
+          "**Reminder:** This pull request has a merge-by date coming up within the next 24 hours. Please review this PR as soon as possible."
+        )
+    );
 
     if (existingComment != null) {
       continue;
     }
 
     // Make a comment on the PR and tag reviewers
-    const body = `**Reminder:** This pull request has a merge-by date coming up within the next 24 hours. Please review this PR as soon as possible.\n\n${pr.reviewers.map((r) => `@${r.login}`).join(" ")}`
+    const body = `**Reminder:** This pull request has a merge-by date coming up within the next 24 hours. Please review this PR as soon as possible.\n\n${pr.reviewers
+      .map((r) => `@${r.login}`)
+      .join(" ")}`;
     await github.rest.issues.createComment({
       owner,
       repo,
       issue_number: pr.number,
-      body
+      body,
     });
   }
 };
 
 /**
  * Fetches PRs with a merge-by date < 1 week from now.
- * 
+ *
  * @param {Object} dayJs Day.js exports for manipulating/querying time differences
  * @param {Object} github The OctoKit/rest.js API for making requests to GitHub
  * @param {string} owner The owner of the repository (user or organization)
@@ -158,40 +163,70 @@ const notifyUsers = async ({ dayJs, github, owner, pullRequests, repo, today }) 
  */
 const fetchPullRequests = async ({ dayJs, github, owner, repo, today }) => {
   const nextWeek = today.add(7, "day");
-  return (await Promise.all((await github.rest.pulls.list({
-    owner,
-    repo,
-    state: "open"
-  }))?.data.filter((pr) => !pr.draft)
-    .map(async (pr) => {
-      const comments = (await github.rest.issues.listComments({ owner, repo, issue_number: pr.number })).data;
-      // Attempt to parse the merge-by date from the bot comment
-      const existingComment = comments?.find((comment) =>
-        comment.user.login === "github-actions[bot]" && comment.body.includes("**📅 Suggested merge-by date:"));
+  return (
+    await Promise.all(
+      (
+        await github.rest.pulls.list({
+          owner,
+          repo,
+          state: "open",
+        })
+      )?.data
+        .filter((pr) => !pr.draft)
+        .map(async (pr) => {
+          const comments = (
+            await github.rest.issues.listComments({
+              owner,
+              repo,
+              issue_number: pr.number,
+            })
+          ).data;
+          // Attempt to parse the merge-by date from the bot comment
+          const existingComment = comments?.find(
+            (comment) =>
+              comment.user.login === "github-actions[bot]" &&
+              comment.body.includes("**📅 Suggested merge-by date:")
+          );
 
-      const reviews = (await github.rest.pulls.listReviews({
-        owner,
-        repo,
-        pull_number: pr.number,
-      })).data;
+          const reviews = (
+            await github.rest.pulls.listReviews({
+              owner,
+              repo,
+              pull_number: pr.number,
+            })
+          ).data;
 
-      const hasTwoReviews = reviews.reduce((all, review) => review.state === "APPROVED" ? all + 1 : all, 0) >= 2;
+          const hasTwoReviews =
+            reviews.reduce(
+              (all, review) => (review.state === "APPROVED" ? all + 1 : all),
+              0
+            ) >= 2;
 
-      // Filter out reviewers if they have already reviewed and approved the pull request
-      const reviewersNotApproved = pr.requested_reviewers
-        .filter((reviewer) => 
-          reviews.find((review) => review.state === "APPROVED" && reviewer.login === review.user.login) == null);
+          // Filter out reviewers if they have already reviewed and approved the pull request
+          const reviewersNotApproved = pr.requested_reviewers.filter(
+            (reviewer) =>
+              reviews.find(
+                (review) =>
+                  review.state === "APPROVED" &&
+                  reviewer.login === review.user.login
+              ) == null
+          );
 
-      return {
-        number: pr.number,
-        title: pr.title,
-        author: pr.user.login,
-        hasReviews: hasTwoReviews,
-        mergeable: pr.mergeable,
-        reviewers: reviewersNotApproved,
-        mergeBy: existingComment?.body.substring(existingComment.body.lastIndexOf("*") + 1).trim()
-      };
-    }))).filter((pr) => {
+          return {
+            number: pr.number,
+            title: pr.title,
+            author: pr.user.login,
+            hasReviews: hasTwoReviews,
+            mergeable: pr.mergeable,
+            reviewers: reviewersNotApproved,
+            mergeBy: existingComment?.body
+              .substring(existingComment.body.lastIndexOf("*") + 1)
+              .trim(),
+          };
+        })
+    )
+  )
+    .filter((pr) => {
       if (pr.mergeBy == null) {
         return true;
       }
@@ -199,19 +234,26 @@ const fetchPullRequests = async ({ dayJs, github, owner, repo, today }) => {
       // Filter out any PRs that have merge-by dates > 1 week from now
       const mergeByDate = dayJs(pr.mergeBy);
       return nextWeek.diff(mergeByDate, "day") <= 7;
-    }).reverse();
-}
+    })
+    .reverse();
+};
 
 module.exports = async ({ github, context }) => {
   const dayJs = require("dayjs");
   const today = dayJs();
   const owner = context.repo.owner;
   const repo = context.repo.repo;
-  const pullRequests = await fetchPullRequests({ dayJs, github, owner, repo, today });
+  const pullRequests = await fetchPullRequests({
+    dayJs,
+    github,
+    owner,
+    repo,
+    today,
+  });
   // Look over existing PRs, grab all PRs with a merge-by date <= 1w from now, and update the issue with the new table
   await scanPRsAndUpdateTable({ github, owner, pullRequests, repo });
   // Notify users for PRs with merge-by dates coming up within 24hrs from now
   if (context.eventName === "schedule") {
     await notifyUsers({ dayJs, github, owner, pullRequests, repo, today });
   }
-}
+};

--- a/merge-by/scripts/build-table-and-notify.js
+++ b/merge-by/scripts/build-table-and-notify.js
@@ -169,7 +169,7 @@ const notifyUsers = async ({
  */
 const fetchPullRequests = async ({ dayJs, github, owner, repo, today }) => {
   const nextWeek = today.add(7, "day");
-  return getPullRequests({ dayJs, github })
+  return (await getPullRequests({ dayJs, github, owner, repo }))
     .filter((pr) => {
       if (pr.mergeBy == null) {
         return true;

--- a/merge-by/scripts/build-table-and-notify.js
+++ b/merge-by/scripts/build-table-and-notify.js
@@ -28,13 +28,16 @@ const getDaysReady = (days) => {
  * @returns
  */
 const buildTableRow = (owner, repo, pr) =>
-  `| [#${pr.number}](https://github.com/${owner}/${repo}/pull/${pr.number
-  }) | [**${pr.title.trim()}**](https://github.com/${owner}/${repo}/pull/${pr.number
+  `| [#${pr.number}](https://github.com/${owner}/${repo}/pull/${
+    pr.number
+  }) | [**${pr.title.trim()}**](https://github.com/${owner}/${repo}/pull/${
+    pr.number
   }) | ${pr.author} | ${pr.mergeBy ?? "N/A"} | ${getDaysReady(
     pr.daysSinceReady
-  )} | ${pr.hasReviews && pr.mergeable !== false
-    ? ":white_check_mark:"
-    : ":white_large_square:"
+  )} | ${
+    pr.hasReviews && pr.mergeable !== false
+      ? ":white_check_mark:"
+      : ":white_large_square:"
   }`;
 
 const TABLE_HEADER = `
@@ -179,7 +182,7 @@ const fetchPullRequests = async ({ dayJs, github, owner, repo, today }) => {
     .reverse();
 };
 
-module.exports = async ({ github, context }) => {
+module.exports = async ({ github, context, require }) => {
   const dayJs = require("dayjs");
   const today = dayJs();
   const owner = context.repo.owner;

--- a/merge-by/scripts/bump-dates.js
+++ b/merge-by/scripts/bump-dates.js
@@ -1,0 +1,48 @@
+module.exports = async ({ github, context }) => {
+    // Ignore PR "opened" events if the PR was opened as draft
+    const wasJustOpened = context.action === "opened";
+    if (wasJustOpened && context.payload.pull_request.draft) {
+        return;
+    }
+
+    const wasJustPushed = context.action === "synchronize";
+    
+    const owner = context.repo.owner;
+    const repo = context.repo.repo;
+    const comments = (await github.rest.issues.listComments({ owner, repo, issue_number: context.payload.pull_request.number }))?.data;
+    const existingComment = comments?.find((comment) => 
+        comment.user.login === "github-actions[bot]" && comment.body.includes("**📅 Suggested merge-by date:"));
+    
+    // For existing PRs, only post the date if a bot comment doesn't already exist.
+    if (context.payload.pull_request.draft || (wasJustPushed && existingComment != null)) {
+        return;
+    }
+    
+    // Determine new merge-by date based on the last time the PR was marked as ready
+    const currentTime = new Date();
+    const mergeBy = new Date();
+    mergeBy.setDate(currentTime.getDate() + 14);
+    const mergeByDate = mergeBy.toLocaleDateString("en-US");
+    
+    // Check if the bot already made a comment on this PR
+    const body = `**📅 Suggested merge-by date:** ${mergeByDate}`;
+    
+    // Update the existing comment if one exists, or post a new comment with the merge-by date
+    if (existingComment != null) {
+        console.log(`Updated existing comment (ID ${existingComment.id}) with new merge-by date: ${mergeByDate}`);
+        await github.rest.issues.updateComment({
+            owner,
+            repo,
+            comment_id: existingComment.id,
+            body
+        });
+    } else {
+        console.log(`Posted comment with new merge-by date: ${mergeByDate}`);
+        await github.rest.issues.createComment({
+            owner,
+            repo,
+            issue_number: context.payload.pull_request.number,
+            body,
+        });
+    }
+}

--- a/merge-by/scripts/bump-dates.js
+++ b/merge-by/scripts/bump-dates.js
@@ -13,8 +13,8 @@ module.exports = async ({ github, context }) => {
     const existingComment = comments?.find((comment) => 
         comment.user.login === "github-actions[bot]" && comment.body.includes("**📅 Suggested merge-by date:"));
     
-    // For existing PRs, only post the date if a bot comment doesn't already exist.
-    if (context.payload.pull_request.draft || (wasJustPushed && existingComment != null)) {
+    // For existing PRs, only post the date if the PR isn't in draft.
+    if (context.payload.pull_request.draft) {
         return;
     }
     

--- a/merge-by/scripts/graphql.js
+++ b/merge-by/scripts/graphql.js
@@ -1,5 +1,5 @@
 const QUERIES = {
-    GET_DISCUSSIONS: `#graphql query($owner:String!, $repo:String!) {
+    GET_DISCUSSIONS: `query($owner:String!, $repo:String!) {
         repository(owner:$owner, name:$repo) {
             id
 
@@ -22,14 +22,14 @@ const QUERIES = {
 };
 
 const MUTATIONS = {
-    CREATE_DISCUSSION: `#graphql mutation($input:CreateDiscussionInput!) {
+    CREATE_DISCUSSION: `mutation($input:CreateDiscussionInput!) {
         createDiscussion(input: $input) {
             discussion {
                 id
             }
         }
     }`,
-    UPDATE_DISCUSSION: `#graphql mutation($input:UpdateDiscussionInput!) {
+    UPDATE_DISCUSSION: `mutation($input:UpdateDiscussionInput!) {
         updateDiscussion(input: $input) {
             discussion {
                 id

--- a/merge-by/scripts/graphql.js
+++ b/merge-by/scripts/graphql.js
@@ -1,0 +1,39 @@
+export const QUERIES = {
+    GET_DISCUSSIONS: `#graphql query($owner:String!, $repo:String!) {
+        repository(owner:$owner, name:$repo) {
+            id
+
+            discussionCategories(first: 100) {
+                nodes {
+                    id
+                    name
+                }
+            }
+
+            discussions(first: 100) {
+                nodes {
+                    id
+                    body
+                    title
+                }
+            }
+        }
+    }`,
+};
+
+export const MUTATIONS = {
+    CREATE_DISCUSSION: `#graphql mutation($input:CreateDiscussionInput!) {
+        createDiscussion(input: $input) {
+            discussion {
+                id
+            }
+        }
+    }`,
+    UPDATE_DISCUSSION: `#graphql mutation($input:UpdateDiscussionInput!) {
+        updateDiscussion(input: $input) {
+            discussion {
+                id
+            }
+        }
+    }`,
+};

--- a/merge-by/scripts/graphql.js
+++ b/merge-by/scripts/graphql.js
@@ -1,4 +1,4 @@
-export const QUERIES = {
+const QUERIES = {
     GET_DISCUSSIONS: `#graphql query($owner:String!, $repo:String!) {
         repository(owner:$owner, name:$repo) {
             id
@@ -21,7 +21,7 @@ export const QUERIES = {
     }`,
 };
 
-export const MUTATIONS = {
+const MUTATIONS = {
     CREATE_DISCUSSION: `#graphql mutation($input:CreateDiscussionInput!) {
         createDiscussion(input: $input) {
             discussion {
@@ -36,4 +36,9 @@ export const MUTATIONS = {
             }
         }
     }`,
+};
+
+module.exports = {
+    QUERIES,
+    MUTATIONS
 };

--- a/merge-by/scripts/promises.js
+++ b/merge-by/scripts/promises.js
@@ -86,7 +86,6 @@ async function getPullRequests({ dayJs, github, owner, repo }) {
                     }
                 }
 
-                console.log("timeline: ", JSON.stringify(timeLineLastToFirst));
                 return {
                     number: pr.number,
                     title: pr.title,

--- a/merge-by/scripts/promises.js
+++ b/merge-by/scripts/promises.js
@@ -19,7 +19,7 @@
  * @param {Object} github The github object for interacting w/ REST APIs
  * @returns {PullInfo[]} List of metadata for each pull request
  */
-export async function getPullRequests({ dayJs, github }) {
+async function getPullRequests({ dayJs, github }) {
     return (
         await github.rest.pulls.list({
             owner,
@@ -94,3 +94,7 @@ export async function getPullRequests({ dayJs, github }) {
             };
         });
 }
+
+module.exports = {
+    getPullRequests
+};

--- a/merge-by/scripts/promises.js
+++ b/merge-by/scripts/promises.js
@@ -1,26 +1,32 @@
 /**
  * Metadata about a pull request.
- * @typedef {{ number: number;
+ *
+ * @typedef {{
+ *   number: number;
  *   title: string;
  *   author: string;
  *   hasReviews: boolean;
  *   mergeable: boolean;
  *   reviewers: { login: string }[];
+ *   daysSinceReady: number;
  *   mergeBy: string;
- * }} PullInfo[]
+ * }} PullInfo
  */
 
 /**
- * 
- * @param {Object} github The github object for interacting w/ REST APIs 
+ *
+ * @param {Object} dayJs Day.js exports for manipulating/querying time differences
+ * @param {Object} github The github object for interacting w/ REST APIs
  * @returns {PullInfo[]} List of metadata for each pull request
  */
-export async function getPullRequests({ github }) {
-    return (await github.rest.pulls.list({
-        owner,
-        repo,
-        state: "open",
-    }))?.data
+export async function getPullRequests({ dayJs, github }) {
+    return (
+        await github.rest.pulls.list({
+            owner,
+            repo,
+            state: "open",
+        })
+    )?.data
         .filter((pr) => !pr.draft)
         .map(async (pr) => {
             const comments = (
@@ -61,6 +67,19 @@ export async function getPullRequests({ github }) {
                     ) == null
             );
 
+            // Check if this PR was marked as ready
+            const timeline = (
+                await github.rest.issues.listEventsForTimeline({
+                    owner,
+                    repo,
+                    issue_number: pr.number,
+                })
+            ).data;
+            const timeLineLastToFirst = timeline.reverse();
+            const lastReadyEvent = timeLineLastToFirst.findIndex((ev) => ev.event === "ready_for_review");
+            const daysSinceReady = pr.draft ? -1 :
+                dayJs().diff(dayjs(timeLineLastToFirst(lastReadyEvent).created_at), "day");
+
             return {
                 number: pr.number,
                 title: pr.title,
@@ -68,6 +87,7 @@ export async function getPullRequests({ github }) {
                 hasReviews: hasTwoReviews,
                 mergeable: pr.mergeable,
                 reviewers: reviewersNotApproved,
+                daysSinceReady,
                 mergeBy: existingComment?.body
                     .substring(existingComment.body.lastIndexOf("*") + 1)
                     .trim(),

--- a/merge-by/scripts/promises.js
+++ b/merge-by/scripts/promises.js
@@ -1,3 +1,20 @@
+/**
+ * Metadata about a pull request.
+ * @typedef {{ number: number;
+ *   title: string;
+ *   author: string;
+ *   hasReviews: boolean;
+ *   mergeable: boolean;
+ *   reviewers: { login: string }[];
+ *   mergeBy: string;
+ * }} PullInfo[]
+ */
+
+/**
+ * 
+ * @param {Object} github The github object for interacting w/ REST APIs 
+ * @returns {PullInfo[]} List of metadata for each pull request
+ */
 export async function getPullRequests({ github }) {
     return (await github.rest.pulls.list({
         owner,

--- a/merge-by/scripts/promises.js
+++ b/merge-by/scripts/promises.js
@@ -76,9 +76,11 @@ async function getPullRequests({ dayJs, github, owner, repo }) {
                 ).data;
                 const timeLineLastToFirst = timeline.reverse();
                 const lastReadyEvent = timeLineLastToFirst.findIndex((ev) => ev.event === "ready_for_review");
-                const daysSinceReady = pr.draft ? -1 :
-                    dayJs().diff(dayJs(timeLineLastToFirst(lastReadyEvent).created_at), "day");
+                // const daysSinceReady = pr.draft || lastReadyEvent === -1 ? -1 :
+                //     dayJs().diff(dayJs(timeLineLastToFirst[lastReadyEvent].created_at), "day");
 
+                console.log("timeline: ", JSON.stringify(timeLineLastToFirst));
+                console.log("last ready event: ", JSON.stringify(lastReadyEvent));
                 return {
                     number: pr.number,
                     title: pr.title,
@@ -86,7 +88,7 @@ async function getPullRequests({ dayJs, github, owner, repo }) {
                     hasReviews: hasTwoReviews,
                     mergeable: pr.mergeable,
                     reviewers: reviewersNotApproved,
-                    daysSinceReady,
+                    daysSinceReady: 0,
                     mergeBy: existingComment?.body
                         .substring(existingComment.body.lastIndexOf("*") + 1)
                         .trim(),

--- a/merge-by/scripts/promises.js
+++ b/merge-by/scripts/promises.js
@@ -20,79 +20,78 @@
  * @returns {PullInfo[]} List of metadata for each pull request
  */
 async function getPullRequests({ dayJs, github }) {
-    return (
+    return (await Promise.all(
         await github.rest.pulls.list({
             owner,
             repo,
             state: "open",
-        })
-    )?.data
-        .filter((pr) => !pr.draft)
-        .map(async (pr) => {
-            const comments = (
-                await github.rest.issues.listComments({
-                    owner,
-                    repo,
-                    issue_number: pr.number,
-                })
-            ).data;
-            // Attempt to parse the merge-by date from the bot comment
-            const existingComment = comments?.find(
-                (comment) =>
-                    comment.user.login === "github-actions[bot]" &&
-                    comment.body.includes("**📅 Suggested merge-by date:")
-            );
+        })?.data
+            .filter((pr) => !pr.draft)
+            .map(async (pr) => {
+                const comments = (
+                    await github.rest.issues.listComments({
+                        owner,
+                        repo,
+                        issue_number: pr.number,
+                    })
+                ).data;
+                // Attempt to parse the merge-by date from the bot comment
+                const existingComment = comments?.find(
+                    (comment) =>
+                        comment.user.login === "github-actions[bot]" &&
+                        comment.body.includes("**📅 Suggested merge-by date:")
+                );
 
-            const reviews = (
-                await github.rest.pulls.listReviews({
-                    owner,
-                    repo,
-                    pull_number: pr.number,
-                })
-            ).data;
+                const reviews = (
+                    await github.rest.pulls.listReviews({
+                        owner,
+                        repo,
+                        pull_number: pr.number,
+                    })
+                ).data;
 
-            const hasTwoReviews =
-                reviews.reduce(
-                    (all, review) => (review.state === "APPROVED" ? all + 1 : all),
-                    0
-                ) >= 2;
+                const hasTwoReviews =
+                    reviews.reduce(
+                        (all, review) => (review.state === "APPROVED" ? all + 1 : all),
+                        0
+                    ) >= 2;
 
-            // Filter out reviewers if they have already reviewed and approved the pull request
-            const reviewersNotApproved = pr.requested_reviewers.filter(
-                (reviewer) =>
-                    reviews.find(
-                        (review) =>
-                            review.state === "APPROVED" &&
-                            reviewer.login === review.user.login
-                    ) == null
-            );
+                // Filter out reviewers if they have already reviewed and approved the pull request
+                const reviewersNotApproved = pr.requested_reviewers.filter(
+                    (reviewer) =>
+                        reviews.find(
+                            (review) =>
+                                review.state === "APPROVED" &&
+                                reviewer.login === review.user.login
+                        ) == null
+                );
 
-            // Check if this PR was marked as ready
-            const timeline = (
-                await github.rest.issues.listEventsForTimeline({
-                    owner,
-                    repo,
-                    issue_number: pr.number,
-                })
-            ).data;
-            const timeLineLastToFirst = timeline.reverse();
-            const lastReadyEvent = timeLineLastToFirst.findIndex((ev) => ev.event === "ready_for_review");
-            const daysSinceReady = pr.draft ? -1 :
-                dayJs().diff(dayjs(timeLineLastToFirst(lastReadyEvent).created_at), "day");
+                // Check if this PR was marked as ready
+                const timeline = (
+                    await github.rest.issues.listEventsForTimeline({
+                        owner,
+                        repo,
+                        issue_number: pr.number,
+                    })
+                ).data;
+                const timeLineLastToFirst = timeline.reverse();
+                const lastReadyEvent = timeLineLastToFirst.findIndex((ev) => ev.event === "ready_for_review");
+                const daysSinceReady = pr.draft ? -1 :
+                    dayJs().diff(dayjs(timeLineLastToFirst(lastReadyEvent).created_at), "day");
 
-            return {
-                number: pr.number,
-                title: pr.title,
-                author: pr.user.login,
-                hasReviews: hasTwoReviews,
-                mergeable: pr.mergeable,
-                reviewers: reviewersNotApproved,
-                daysSinceReady,
-                mergeBy: existingComment?.body
-                    .substring(existingComment.body.lastIndexOf("*") + 1)
-                    .trim(),
-            };
-        });
+                return {
+                    number: pr.number,
+                    title: pr.title,
+                    author: pr.user.login,
+                    hasReviews: hasTwoReviews,
+                    mergeable: pr.mergeable,
+                    reviewers: reviewersNotApproved,
+                    daysSinceReady,
+                    mergeBy: existingComment?.body
+                        .substring(existingComment.body.lastIndexOf("*") + 1)
+                        .trim(),
+                };
+            })));
 }
 
 module.exports = {

--- a/merge-by/scripts/promises.js
+++ b/merge-by/scripts/promises.js
@@ -75,12 +75,12 @@ async function getPullRequests({ dayJs, github, owner, repo }) {
                     })
                 ).data;
                 const timeLineLastToFirst = timeline.reverse();
-                const lastReadyEvent = timeLineLastToFirst.findIndex((ev) => ev.event === "ready_for_review");
-                // const daysSinceReady = pr.draft || lastReadyEvent === -1 ? -1 :
-                //     dayJs().diff(dayJs(timeLineLastToFirst[lastReadyEvent].created_at), "day");
+                const lastReadyEvent = pr.draft ? timeLineLastToFirst.findIndex((ev) => ev.event === "ready_for_review") :
+                    new Date(pr.created_at);
+                const daysSinceReady = pr.draft || lastReadyEvent === -1 ? -1 :
+                    dayJs().diff(dayJs(timeLineLastToFirst[lastReadyEvent].created_at), "day");
 
                 console.log("timeline: ", JSON.stringify(timeLineLastToFirst));
-                console.log("last ready event: ", JSON.stringify(lastReadyEvent));
                 return {
                     number: pr.number,
                     title: pr.title,
@@ -88,7 +88,7 @@ async function getPullRequests({ dayJs, github, owner, repo }) {
                     hasReviews: hasTwoReviews,
                     mergeable: pr.mergeable,
                     reviewers: reviewersNotApproved,
-                    daysSinceReady: 0,
+                    daysSinceReady: daysSinceReady,
                     mergeBy: existingComment?.body
                         .substring(existingComment.body.lastIndexOf("*") + 1)
                         .trim(),

--- a/merge-by/scripts/promises.js
+++ b/merge-by/scripts/promises.js
@@ -77,7 +77,7 @@ async function getPullRequests({ dayJs, github, owner, repo }) {
                 const timeLineLastToFirst = timeline.reverse();
                 const lastReadyEvent = timeLineLastToFirst.findIndex((ev) => ev.event === "ready_for_review");
                 const daysSinceReady = pr.draft ? -1 :
-                    dayJs().diff(dayjs(timeLineLastToFirst(lastReadyEvent).created_at), "day");
+                    dayJs().diff(dayJs(timeLineLastToFirst(lastReadyEvent).created_at), "day");
 
                 return {
                     number: pr.number,

--- a/merge-by/scripts/promises.js
+++ b/merge-by/scripts/promises.js
@@ -75,10 +75,6 @@ async function getPullRequests({ dayJs, github, owner, repo }) {
                     })
                 ).data;
                 const timeLineLastToFirst = timeline.reverse();
-                const lastReadyEvent = pr.draft ? timeLineLastToFirst.findIndex((ev) => ev.event === "ready_for_review") :
-                    new Date(pr.created_at);
-                const daysSinceReady = pr.draft || lastReadyEvent === -1 ? -1 :
-                    dayJs().diff(dayJs(timeLineLastToFirst[lastReadyEvent].created_at), "day");
 
                 console.log("timeline: ", JSON.stringify(timeLineLastToFirst));
                 return {
@@ -88,7 +84,7 @@ async function getPullRequests({ dayJs, github, owner, repo }) {
                     hasReviews: hasTwoReviews,
                     mergeable: pr.mergeable,
                     reviewers: reviewersNotApproved,
-                    daysSinceReady: daysSinceReady,
+                    daysSinceReady: 0,
                     mergeBy: existingComment?.body
                         .substring(existingComment.body.lastIndexOf("*") + 1)
                         .trim(),

--- a/merge-by/scripts/promises.js
+++ b/merge-by/scripts/promises.js
@@ -26,7 +26,6 @@ async function getPullRequests({ dayJs, github, owner, repo }) {
             repo,
             state: "open",
         }))?.data
-            .filter((pr) => !pr.draft)
             .map(async (pr) => {
                 const comments = (
                     await github.rest.issues.listComments({

--- a/merge-by/scripts/promises.js
+++ b/merge-by/scripts/promises.js
@@ -1,0 +1,59 @@
+export async function getPullRequests({ github }) {
+    return (await github.rest.pulls.list({
+        owner,
+        repo,
+        state: "open",
+    }))?.data
+        .filter((pr) => !pr.draft)
+        .map(async (pr) => {
+            const comments = (
+                await github.rest.issues.listComments({
+                    owner,
+                    repo,
+                    issue_number: pr.number,
+                })
+            ).data;
+            // Attempt to parse the merge-by date from the bot comment
+            const existingComment = comments?.find(
+                (comment) =>
+                    comment.user.login === "github-actions[bot]" &&
+                    comment.body.includes("**📅 Suggested merge-by date:")
+            );
+
+            const reviews = (
+                await github.rest.pulls.listReviews({
+                    owner,
+                    repo,
+                    pull_number: pr.number,
+                })
+            ).data;
+
+            const hasTwoReviews =
+                reviews.reduce(
+                    (all, review) => (review.state === "APPROVED" ? all + 1 : all),
+                    0
+                ) >= 2;
+
+            // Filter out reviewers if they have already reviewed and approved the pull request
+            const reviewersNotApproved = pr.requested_reviewers.filter(
+                (reviewer) =>
+                    reviews.find(
+                        (review) =>
+                            review.state === "APPROVED" &&
+                            reviewer.login === review.user.login
+                    ) == null
+            );
+
+            return {
+                number: pr.number,
+                title: pr.title,
+                author: pr.user.login,
+                hasReviews: hasTwoReviews,
+                mergeable: pr.mergeable,
+                reviewers: reviewersNotApproved,
+                mergeBy: existingComment?.body
+                    .substring(existingComment.body.lastIndexOf("*") + 1)
+                    .trim(),
+            };
+        });
+}

--- a/merge-by/scripts/promises.js
+++ b/merge-by/scripts/promises.js
@@ -19,13 +19,13 @@
  * @param {Object} github The github object for interacting w/ REST APIs
  * @returns {PullInfo[]} List of metadata for each pull request
  */
-async function getPullRequests({ dayJs, github }) {
-    return (await Promise.all(
-        await github.rest.pulls.list({
+async function getPullRequests({ dayJs, github, owner, repo }) {
+    return Promise.all(
+        (await github.rest.pulls.list({
             owner,
             repo,
             state: "open",
-        })?.data
+        }))?.data
             .filter((pr) => !pr.draft)
             .map(async (pr) => {
                 const comments = (
@@ -91,7 +91,7 @@ async function getPullRequests({ dayJs, github }) {
                         .substring(existingComment.body.lastIndexOf("*") + 1)
                         .trim(),
                 };
-            })));
+            }));
 }
 
 module.exports = {

--- a/merge-by/scripts/promises.js
+++ b/merge-by/scripts/promises.js
@@ -17,10 +17,13 @@
  *
  * @param {Object} dayJs Day.js exports for manipulating/querying time differences
  * @param {Object} github The github object for interacting w/ REST APIs
+ * @param {string} owner The repository owner (e.g. zowe)
+ * @param {string} repo The name of the repository
+ * @param {boolean} reverse Whether to reverse the order of results
  * @returns {PullInfo[]} List of metadata for each pull request
  */
-async function getPullRequests({ dayJs, github, owner, repo }) {
-    return Promise.all(
+async function getPullRequests({ dayJs, github, owner, repo, reverse }) {
+    const res = await Promise.all(
         (await github.rest.pulls.list({
             owner,
             repo,
@@ -99,6 +102,8 @@ async function getPullRequests({ dayJs, github, owner, repo }) {
                         .trim(),
                 };
             }));
+    
+    return reverse ? res.reverse() : res;
 }
 
 module.exports = {


### PR DESCRIPTION
We should probably squash & merge because of all the commits from testing 😅 

This adds a new composite action that:
- Will track each opened PR (ready or draft) and determine an appropriate merge-by date (usually 2 weeks after marked as ready)
- Posts a comment on each PR when a PR is within 24 hours of its merge-by date, tagging reviewers who haven't yet approved