### PR TITLE
fix validate-package-json skip file: and link: dependencies

### DIFF
--- a/validate-package-json/validate-package-json.sh
+++ b/validate-package-json/validate-package-json.sh
@@ -64,6 +64,11 @@ while read -r package; do
             >&2 echo "Warning: cannot validate version of ${package}@${version}."
             continue
           fi
+          version_first_5chars=$(echo "${version}" | cut -c 1-5)
+          if [ "${version_first_5chars}" = "file:" -o "${version_first_5chars}" = "link:" ]; then
+            >&2 echo "Warning: cannot validate version of ${package}@${version}."
+            continue
+          fi
           time=$(npm view "${package}@${version}" time --json 2>/dev/null | jq -r ".\"${version}\"")
           time_rc=$?
           echo "    - ${time}"


### PR DESCRIPTION
Summary:
The validate-package-json script fails when a package.json contains dependencies using file: or link: protocol prefixes. These are local path references and cannot be looked up on the npm registry, causing npm view to fail and the script to exit with:

`Error: cannot find release date of <package>@file:../some-path`

Fix:
Added a check for  and link: version prefixes alongside the existing git prefix check. These dependencies are now skipped with a warning, since their release dates cannot be validated via the npm registry.